### PR TITLE
fix: ignore non-exportable struct name

### DIFF
--- a/internal/check/checkstruct.go
+++ b/internal/check/checkstruct.go
@@ -53,7 +53,7 @@ func (b *BaseStruct) check() (err error) {
 		if !allowType(m.Type) {
 			b.Members[index].Type = "field"
 		}
-		b.Members[index].NewType = getTypeName(m.Type)
+		b.Members[index].NewType = getNewTypeName(m.Type)
 	}
 	return nil
 }

--- a/internal/check/export.go
+++ b/internal/check/export.go
@@ -18,7 +18,7 @@ func CheckStructs(db *gorm.DB, structs ...interface{}) (bases []*BaseStruct, err
 
 	for _, st := range structs {
 		structType := reflect.TypeOf(st)
-		name := getTypeName(structType.String())
+		name := getStructName(structType.String())
 		base := &BaseStruct{
 			S:             GetSimpleName(name),
 			StructName:    name,

--- a/internal/check/utils.go
+++ b/internal/check/utils.go
@@ -79,10 +79,13 @@ func GetSimpleName(s string) string {
 	return string(strings.ToLower(DelPointerSym(s))[0])
 }
 
-func getTypeName(t string) string {
-	var res string
-	for _, s := range strings.Split(t, ".") {
-		res = s
-	}
-	return strings.Title(res)
+func getNewTypeName(t string) string {
+	list := strings.Split(t, ".")
+	return strings.Title(list[len(list)-1])
+}
+
+// not need capitalize
+func getStructName(t string) string {
+	list := strings.Split(t, ".")
+	return list[len(list)-1]
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
fix get struct name function to ignore non-exportable struct 
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
 `g.Apply(func(models.TestMethod){}, models.User{}, tester{}) // tester will be ignore`
<!-- Your use case -->
