### PR TITLE
feat: binary和varbinary类型字段默认类型从string改为[]byte类型

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -350,11 +350,9 @@ func (g *Generator) Execute() {
 	if g.OutFile == "" {
 		g.OutFile = g.OutPath + "/gen.go"
 	}
-	if _, err := os.Stat(g.OutPath); err != nil {
-		if err := os.MkdirAll(g.OutPath, os.ModePerm); err != nil {
-			g.db.Logger.Error(context.Background(), "create dir fail: %s", err)
-			panic("create query dir fail")
-		}
+	if err := os.MkdirAll(g.OutPath, os.ModePerm); err != nil {
+		g.db.Logger.Error(context.Background(), "create dir fail: %s", err)
+		panic("create query dir fail")
 	}
 	g.queryPkgName = filepath.Base(g.OutPath)
 

--- a/generator.go
+++ b/generator.go
@@ -351,7 +351,7 @@ func (g *Generator) Execute() {
 		g.OutFile = g.OutPath + "/gen.go"
 	}
 	if _, err := os.Stat(g.OutPath); err != nil {
-		if err := os.Mkdir(g.OutPath, os.ModePerm); err != nil {
+		if err := os.MkdirAll(g.OutPath, os.ModePerm); err != nil {
 			g.db.Logger.Error(context.Background(), "create dir fail: %s", err)
 			panic("create query dir fail")
 		}
@@ -491,7 +491,7 @@ func (g *Generator) generateBaseStruct() (err error) {
 		}
 
 		if !created {
-			if err := os.Mkdir(outPath, os.ModePerm); err != nil {
+			if err := os.MkdirAll(outPath, os.ModePerm); err != nil {
 				g.db.Logger.Error(context.Background(), "create dir fail: %s", err)
 				panic("create base struct dir fail")
 			}

--- a/internal/check/gen_structs.go
+++ b/internal/check/gen_structs.go
@@ -42,6 +42,8 @@ var (
 		"tinytext":   func(string) string { return "string" },
 		"mediumtext": func(string) string { return "string" },
 		"longtext":   func(string) string { return "string" },
+		"binary":     func(string) string { return "[]byte" },
+		"varbinary":  func(string) string { return "[]byte" },
 		"tinyblob":   func(string) string { return "[]byte" },
 		"blob":       func(string) string { return "[]byte" },
 		"mediumblob": func(string) string { return "[]byte" },


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
支持binary和varbinary两种字段类型，之前的默认类型是string，这两种类型在go中更适合使用[]byte

### User Case Description
我通过varbinary保存IP地址，但是生成的数据类型是string，导致net.IP不能直接保存到数据库
