### PR TITLE
fix(generate): make the generated code conform to the Uber go specifi…

### DIFF
--- a/internal/check/clause.go
+++ b/internal/check/clause.go
@@ -151,7 +151,7 @@ func (s *Slices) GetName(status model.Status) string {
 }
 
 func (s *Slices) appendIfCond(name, cond, result string) {
-	s.tmpl = append(s.tmpl, fmt.Sprintf("%s = append(%s, helper.Cond{%s, %s})", name, name, cond, result))
+	s.tmpl = append(s.tmpl, fmt.Sprintf("%s = append(%s, helper.Cond{Cond: %s, Result: %s})", name, name, cond, result))
 }
 
 func (s *Slices) appendSetValue(name, result string) {


### PR DESCRIPTION
The `DIY Method`gen result does not pass the ci test

because the generated result does not conform to the uber go specification

![image](https://user-images.githubusercontent.com/64912137/141086916-8165bbf6-3c40-4c01-a25d-e910201edb4f.png)

fail code ：
```Go
ifCond0 = append(ifCond0, helper.Cond{appId > 0, " ad.app_id = @appId"})
```

### What did this pull request do?

Modify the generated template

successful code:

```Go
ifCond0 = append(ifCond0, helper.Cond{Cond: appId > 0, Result: " ad.app_id = @appId"})
```

<!-- Your use case -->
