### PR TITLE
fix: Import error if same struct name exists

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -324,7 +324,10 @@ func (g *Generator) generateQueryFile() (err error) {
 
 	// generate query file
 	var buf bytes.Buffer
-	err = render(tmpl.Header, &buf, g.queryPkgName)
+	err = render(tmpl.Header, &buf, map[string]string{
+		"Package":       g.queryPkgName,
+		"StructPkgPath": "",
+	})
 	if err != nil {
 		return err
 	}
@@ -375,7 +378,10 @@ func (g *Generator) generateQueryFile() (err error) {
 func (g *Generator) generateSubQuery(data *genInfo) (err error) {
 	var buf bytes.Buffer
 
-	err = render(tmpl.Header, &buf, g.queryPkgName)
+	err = render(tmpl.Header, &buf, map[string]string{
+		"Package":       g.queryPkgName,
+		"StructPkgPath": data.StructInfo.PkgPath,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/check/export.go
+++ b/internal/check/export.go
@@ -29,7 +29,7 @@ func CheckStructs(db *gorm.DB, structs ...interface{}) (bases []*BaseStruct, err
 			S:             getPureName(name),
 			StructName:    name,
 			NewStructName: uncaptialize(name),
-			StructInfo:    parser.Param{Type: name, Package: getPackageName(structType.String())},
+			StructInfo:    parser.Param{PkgPath: structType.PkgPath(), Type: name, Package: getPackageName(structType.String())},
 			Source:        model.Struct,
 			db:            db,
 		}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -113,6 +113,7 @@ func (i *InterfaceSet) getInterfaceFromFile(filename string, name, Package strin
 
 // Param parameters in method
 type Param struct { // (user model.User)
+	PkgPath   string // package's path: internal/model
 	Package   string // package's name: model
 	Name      string // param's name: user
 	Type      string // param's type: User

--- a/internal/template/base.go
+++ b/internal/template/base.go
@@ -7,7 +7,7 @@ const NotEditMark = `
 `
 
 const Header = NotEditMark + `
-package {{.}}
+package {{.Package}}
 
 import(
 	"database/sql"
@@ -19,6 +19,7 @@ import(
 	"gorm.io/gen"
 	"gorm.io/gen/field"
 	"gorm.io/gen/helper"
+	{{ if .StructPkgPath  }}"{{.StructPkgPath}}"{{ end }}
 )
 `
 


### PR DESCRIPTION
Cannot auto import when the same package name exists

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
gen 使用golang.org/x/tools/imports生成自动导入，在项目中存在多个同名包，并且有相同名字的结构体，imports无法自动处理，会出现导入缺失或导入错误的情况。
在提交中使用反射获取结构体的包路径，生成文件时填充到import ()里面。
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
例如项目结构如下
```text
./internal/models
./internal/models/v2
./internal/models/v2/man.go
./internal/models/man.go
./internal/models/dog.go
```
`./internal/models/v2/man.go`和`./internal/models/man.go`拥有相同的包名(models)，相同的结构体(Man)，imports无法正确处理导入关系。
<!-- Your use case -->
