### PR TITLE
docs(readme): fix document references in READMES && Add translation for unit test

### DIFF
--- a/README.ZH_CN.md
+++ b/README.ZH_CN.md
@@ -116,6 +116,7 @@
           - [`Where` 子句](#where-clause)
           - [`Set` 子句](#set-clause)
         - [方法接口示例](#method-interface-example)
+      - [单元测试](#unit-test)
       - [智能选择字段](#smart-select-fields)
     - [高级教程](#advanced-topics)
       - [查询优化提示（Hints）](#hints)
@@ -1400,7 +1401,7 @@ type User struct {
 users, err := u.WithContext(ctx).Preload(field.Associations).Find()
 ```
 
-`clause.Associations` 不会加载嵌套关联, 嵌套关联加载可以用 [Nested Preloading](#nested_preloading) e.g:
+`clause.Associations` 不会加载嵌套关联, 嵌套关联加载可以用 [Nested Preloading](#nested-preloading) e.g:
 
 ```go
 users, err := u.WithContext(ctx).Preload(u.Orders.OrderItems.Product).Find()

--- a/README.ZH_CN.md
+++ b/README.ZH_CN.md
@@ -1820,6 +1820,63 @@ type Method interface {
 }
 ```
 
+#### <span id="unit-test">单元测试</span>
+
+如果设置了 `WithUnitTest` 方法，就会生成单元测试文件，生成通用查询功能的单元测试代码。
+
+自定义方法的单元测试需要自定义对应的测试用例，它应该和测试文件放在同一个包里。
+
+一个测试用例包含输入和期望结果，输入应和对应的方法参数匹配，期望应和对应的方法返回值相匹配。这将在测试中被断言为 “**Equal（相等）**”。
+
+
+```go
+package query
+
+type Input struct {
+  Args []interface{}
+}
+
+type Expectation struct {
+  Ret []interface{}
+}
+
+type TestCase struct {
+  Input
+  Expectation
+}
+
+/* Table student */
+
+var StudentFindByIdTestCase = []TestCase {
+  {
+    Input{[]interface{}{1}},
+    Expectation{[]interface{}{nil, nil}},
+  },
+}
+```
+
+相应测试代码：
+
+```go
+//FindById select * from @@table where id = @id
+func (s studentDo) FindById(id int64) (result *model.Student, err error) {
+    ///
+}
+
+func Test_student_FindById(t *testing.T) {
+    student := newStudent(db)
+    do := student.WithContext(context.Background()).Debug()
+
+    for i, tt := range StudentFindByIdTestCase {
+        t.Run("FindById_"+strconv.Itoa(i), func(t *testing.T) {
+            res1, res2 := do.FindById(tt.Input.Args[0].(int64))
+            assert(t, "FindById", res1, tt.Expectation.Ret[0])
+            assert(t, "FindById", res2, tt.Expectation.Ret[1])
+        })
+    }
+}
+```
+
 #### <span id="smart-select-fields">智能选择字段</span>
 
 GEN 查询的时候会自动选择你的model定义的字段

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A safer orm base on [GORM](https://github.com/go-gorm/gorm), aims to be develope
           - [`Where` clause](#where-clause)
           - [`Set` clause](#set-clause)
         - [Method interface example](#method-interface-example)
+      - [Unit Test](#unit-test)
       - [Smart select fields](#smart-select-fields)
     - [Advanced Topics](#advanced-topics)
       - [Hints](#hints)
@@ -1418,7 +1419,7 @@ type User struct {
 users, err := u.WithContext(ctx).Preload(field.Associations).Find()
 ```
 
-`clause.Associations` won’t preload nested associations, but you can use it with [Nested Preloading](#nested_preloading) together, e.g:
+`clause.Associations` won’t preload nested associations, but you can use it with [Nested Preloading](#nested-preloading) together, e.g:
 
 ```go
 users, err := u.WithContext(ctx).Preload(u.Orders.OrderItems.Product).Find()
@@ -1831,10 +1832,13 @@ type Method interface {
 ```
 
 #### Unit Test
+
 Unit test file will be generated if `WithUnitTest` is set, which will generate unit test for general query function.
+
 Unit test for DIY method need diy testcase, which should place in the same package with test file.
 
 A testcase contains input and expectation result, input should match the method arguments, expectation should match method return values, which will be asserted **Equal** in test.
+
 ```go
 package query
 
@@ -1859,9 +1863,10 @@ var StudentFindByIdTestCase = []TestCase {
     Expectation{[]interface{}{nil, nil}},
   },
 }
-
 ```
+
 Corresponding test
+
 ```go
 //FindById select * from @@table where id = @id
 func (s studentDo) FindById(id int64) (result *model.Student, err error) {


### PR DESCRIPTION
Fix document references in README.
修复 README 中文档引用。

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

- Supplement the directory of the unit test, add Chinese translation for unit test
补充单元测试的目录并增加单元测试章节中文翻译
- Fix the reference path error of the document in the associated preloading
修复关联预加载中文档的引用路径错误
- Fix the format problem that there are no blank lines before and after some sample codes
修复部分示例代码前后无空行的格式问题



### User Case Description

None.
