### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ func main() {
 
 Generate Mode:
 
-- `gen.WithoutContext` generate code without `WithContext` contrain
+- `gen.WithoutContext` generate code without `WithContext` constraints
 - `gen.WithDefaultQuery` generate code with a default global variable `Q` as a singleton
 
 ### Project Directory

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ func main() {
 
 Generate Mode:
 
-- `gen.WithoutContext` generate code without `WithContext` constraints
+- `gen.WithoutContext` generate code without `WithContext` constraint
 - `gen.WithDefaultQuery` generate code with a default global variable `Q` as a singleton
 
 ### Project Directory


### PR DESCRIPTION
spelling typo in README.md

```diff
- `gen.WithoutContext` generate code without `WithContext` contrain
+ `gen.WithoutContext` generate code without `WithContext` constraint
```

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Fixes a typo in Readme

### User Case Description

<!-- Your use case -->
