### PR TITLE
Add postgres support

### DIFF
--- a/internal/check/mysql/sql.go
+++ b/internal/check/mysql/sql.go
@@ -1,0 +1,14 @@
+package mysql
+
+const (
+	//query table structure
+	columnQuery = "SELECT COLUMN_NAME,COLUMN_COMMENT,DATA_TYPE,IS_NULLABLE,COLUMN_KEY,COLUMN_TYPE,COLUMN_DEFAULT,EXTRA " +
+		"FROM information_schema.COLUMNS " +
+		"WHERE TABLE_SCHEMA = ? AND TABLE_NAME =? " +
+		"ORDER BY ORDINAL_POSITION"
+
+	//query table index
+	indexQuery = "SELECT TABLE_NAME,COLUMN_NAME,INDEX_NAME,SEQ_IN_INDEX,NON_UNIQUE " +
+		"FROM information_schema.STATISTICS " +
+		"WHERE TABLE_SCHEMA = ? AND TABLE_NAME =?"
+)

--- a/internal/check/mysql/table_info.go
+++ b/internal/check/mysql/table_info.go
@@ -1,0 +1,20 @@
+package mysql
+
+import (
+	"gorm.io/gen/internal/model"
+	"gorm.io/gorm"
+)
+
+type TableInfo struct {
+	Db *gorm.DB
+}
+
+//GetTbColumns Mysql struct
+func (t *TableInfo) GetTbColumns(schemaName string, tableName string) (result []*model.Column, err error) {
+	return result, t.Db.Raw(columnQuery, schemaName, tableName).Scan(&result).Error
+}
+
+//GetTbIndex Mysql index
+func (t *TableInfo) GetTbIndex(schemaName string, tableName string) (result []*model.Index, err error) {
+	return result, t.Db.Raw(indexQuery, schemaName, tableName).Scan(&result).Error
+}

--- a/internal/check/postgres/sql.go
+++ b/internal/check/postgres/sql.go
@@ -1,0 +1,1 @@
+package postgres

--- a/internal/check/postgres/sql.go
+++ b/internal/check/postgres/sql.go
@@ -5,14 +5,23 @@ const (
 SELECT
 	c.table_name AS "TABLE_NAME",
 	c.column_name AS "COLUMN_NAME",
-	c.is_nullable AS "IS_NULLABLE",
+	CASE WHEN pd.description IS NULL THEN '' ELSE pd.description END AS "COLUMN_COMMENT",
+	c.data_type AS "DATA_TYPE",
+	CASE WHEN tc.constraint_type = 'PRIMARY KEY' THEN 'PRI' ELSE '' END AS "COLUMN_KEY",
 	c.udt_name AS "COLUMN_TYPE",
-	pd.description AS "COLUMN_COMMENT"
+	c.is_nullable AS "IS_NULLABLE"
 FROM
 	pg_catalog.pg_statio_all_tables psat
 INNER JOIN information_schema."columns" c ON
 	c.table_schema = psat.schemaname
 	AND c.table_name = psat.relname
+LEFT JOIN information_schema.constraint_column_usage ccu ON
+	ccu.table_schema = psat.schemaname
+	AND ccu.table_name = psat.relname
+	AND ccu.column_name = c.column_name
+LEFT JOIN information_schema.table_constraints tc ON
+	tc.constraint_schema = psat.schemaname
+	AND tc.constraint_name = ccu.constraint_name
 LEFT JOIN pg_catalog.pg_description pd ON
 	pd.objoid = psat.relid
 	AND pd.objsubid = c.ordinal_position

--- a/internal/check/postgres/sql.go
+++ b/internal/check/postgres/sql.go
@@ -26,7 +26,7 @@ LEFT JOIN pg_catalog.pg_description pd ON
 	pd.objoid = psat.relid
 	AND pd.objsubid = c.ordinal_position
 WHERE
-	psat.schemaname = ? AND psat.relname = ?
+	psat.relname = ?
 ORDER BY c.ordinal_position`
 
 	indexQuery = `
@@ -48,8 +48,7 @@ WHERE
 	AND a.attnum = ANY(ix.indkey)
 	AND ns."oid" = t.relnamespace
 	AND t.relkind = 'r'
-	AND ns.nspname = ?
-	AND t.relname = ?s
+	AND t.relname = ?
 ORDER BY
 	t.relname,
 	i.relname;`

--- a/internal/check/postgres/sql.go
+++ b/internal/check/postgres/sql.go
@@ -28,4 +28,29 @@ LEFT JOIN pg_catalog.pg_description pd ON
 WHERE
 	psat.schemaname = ? AND psat.relname = ?
 ORDER BY c.ordinal_position`
+
+	indexQuery = `
+SELECT
+	t.relname AS "TABLE_NAME",
+	a.attname AS "COLUMN_NAME",
+	CASE WHEN ix.indisprimary THEN 'PRIMARY' ELSE i.relname END AS "INDEX_NAME",
+	CASE WHEN ix.indisunique THEN 1 ELSE 0 END AS "NON_UNIQUE"
+FROM
+	pg_class t,
+	pg_class i,
+	pg_index ix,
+	pg_namespace ns,
+	pg_attribute a
+WHERE
+	t.oid = ix.indrelid
+	AND i.oid = ix.indexrelid
+	AND a.attrelid = t.oid
+	AND a.attnum = ANY(ix.indkey)
+	AND ns."oid" = t.relnamespace
+	AND t.relkind = 'r'
+	AND ns.nspname = ?
+	AND t.relname = ?s
+ORDER BY
+	t.relname,
+	i.relname;`
 )

--- a/internal/check/postgres/sql.go
+++ b/internal/check/postgres/sql.go
@@ -1,1 +1,22 @@
 package postgres
+
+const (
+	columnQuery = `
+SELECT
+	c.table_name AS "TABLE_NAME",
+	c.column_name AS "COLUMN_NAME",
+	c.is_nullable AS "IS_NULLABLE",
+	c.udt_name AS "COLUMN_TYPE",
+	pd.description AS "COLUMN_COMMENT"
+FROM
+	pg_catalog.pg_statio_all_tables psat
+INNER JOIN information_schema."columns" c ON
+	c.table_schema = psat.schemaname
+	AND c.table_name = psat.relname
+LEFT JOIN pg_catalog.pg_description pd ON
+	pd.objoid = psat.relid
+	AND pd.objsubid = c.ordinal_position
+WHERE
+	psat.schemaname = ? AND psat.relname = ?
+ORDER BY c.ordinal_position`
+)

--- a/internal/check/postgres/table_info.go
+++ b/internal/check/postgres/table_info.go
@@ -16,5 +16,5 @@ func (t *TableInfo) GetTbColumns(schemaName string, tableName string) (result []
 }
 
 func (t *TableInfo) GetTbIndex(schemaName string, tableName string) (result []*model.Index, err error) {
-	panic("not implemented") // TODO: Implement
+	return result, t.Db.Raw(indexQuery, schemaName, tableName).Scan(&result).Error
 }

--- a/internal/check/postgres/table_info.go
+++ b/internal/check/postgres/table_info.go
@@ -12,7 +12,7 @@ type TableInfo struct {
 }
 
 func (t *TableInfo) GetTbColumns(schemaName string, tableName string) (result []*model.Column, err error) {
-	panic("not implemented") // TODO: Implement
+	return result, t.Db.Raw(columnQuery, schemaName, tableName).Scan(&result).Error
 }
 
 func (t *TableInfo) GetTbIndex(schemaName string, tableName string) (result []*model.Index, err error) {

--- a/internal/check/postgres/table_info.go
+++ b/internal/check/postgres/table_info.go
@@ -1,0 +1,20 @@
+package postgres
+
+import (
+	"gorm.io/gen/internal/model"
+	"gorm.io/gorm"
+)
+
+// t *TableInfo gorm.io/gen/internal/check.ITableInfo
+
+type TableInfo struct {
+	Db *gorm.DB
+}
+
+func (t *TableInfo) GetTbColumns(schemaName string, tableName string) (result []*model.Column, err error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (t *TableInfo) GetTbIndex(schemaName string, tableName string) (result []*model.Index, err error) {
+	panic("not implemented") // TODO: Implement
+}

--- a/internal/check/postgres/table_info.go
+++ b/internal/check/postgres/table_info.go
@@ -6,15 +6,16 @@ import (
 )
 
 // t *TableInfo gorm.io/gen/internal/check.ITableInfo
+// the schemaName is the database name, not the schema name of postgres
 
 type TableInfo struct {
 	Db *gorm.DB
 }
 
 func (t *TableInfo) GetTbColumns(schemaName string, tableName string) (result []*model.Column, err error) {
-	return result, t.Db.Raw(columnQuery, schemaName, tableName).Scan(&result).Error
+	return result, t.Db.Raw(columnQuery, tableName).Scan(&result).Error
 }
 
 func (t *TableInfo) GetTbIndex(schemaName string, tableName string) (result []*model.Index, err error) {
-	return result, t.Db.Raw(indexQuery, schemaName, tableName).Scan(&result).Error
+	return result, t.Db.Raw(indexQuery, tableName).Scan(&result).Error
 }

--- a/internal/model/tbl_column.go
+++ b/internal/model/tbl_column.go
@@ -91,11 +91,23 @@ func (c *Column) buildGormTag() string {
 		if idx == nil || idx.IsPrimaryKey() {
 			continue
 		}
+
+		var indexTag string
+		var indexType string
+
 		if idx.IsUnique() {
-			buf.WriteString(fmt.Sprintf(";uniqueIndex:%s,priority:%d", idx.IndexName, idx.SeqInIndex))
+			indexType = "uniqueIndex"
 		} else {
-			buf.WriteString(fmt.Sprintf(";index:%s,priority:%d", idx.IndexName, idx.SeqInIndex))
+			indexType = "index"
 		}
+
+		indexTag = fmt.Sprintf(";%s:%s", indexType, idx.IndexName)
+
+		if idx.SeqInIndex > 0 {
+			indexTag += fmt.Sprintf(",priority:%d", idx.SeqInIndex)
+		}
+
+		buf.WriteString(indexTag)
 	}
 	if c.withDefaultValue() {
 		buf.WriteString(fmt.Sprintf(";default:%s", c.ColumnDefault))


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
For issue https://github.com/go-gorm/gen/issues/271, add postgres table models generate.

### User Case Description
Original plan is use the migrator in gorm and each dialector, but due the limitation of the [Migrator interface](https://github.com/go-gorm/gorm/blob/master/migrator.go#L44) , seems it's impossible to fetch the table details at this moment. So I have to add an additional `ITableInfo` implementation to generate the postgre table models.

When dialector name is `postgres`, use new table schema query sql, otherwise keep the original one.

Because I didn't find a method to get the `SEQ_IN_INDEX` in postgres so far, add a condition to the `priority` tag when `FieldWithIndexTag` equals to.
