### PR TITLE
fix: generator GenerateAllTable unuse opts

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -161,7 +161,7 @@ func (g *Generator) GenerateAllTable(opts ...FieldOpt) (tableModels []interface{
 
 	tableModels = make([]interface{}, len(tableList))
 	for i, tableName := range tableList {
-		tableModels[i] = g.GenerateModel(tableName)
+		tableModels[i] = g.GenerateModel(tableName, opts...)
 	}
 	return tableModels
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
GenerateAllTable has opts args, but unuse it.
### User Case Description

<!-- Your use case -->
GenerateAllTable with FieldOpt