### PR TITLE
feat: add `gen.FieldComment` to rewrite struct comment

### DIFF
--- a/README.ZH_CN.md
+++ b/README.ZH_CN.md
@@ -260,6 +260,7 @@ FieldNew           // create new field
 FieldIgnore        // ignore field
 FieldIgnoreReg     // ignore field (match with regexp)
 FieldRename        // rename field in struct
+FieldComment       // specify field comment in generated struct
 FieldType          // specify field type
 FieldTypeReg       // specify field type (match with regexp)
 FieldTag           // specify gorm and json tag

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ FieldNew           // create new field
 FieldIgnore        // ignore field
 FieldIgnoreReg     // ignore field (match with regexp)
 FieldRename        // rename field in struct
+FieldComment       // specify field comment in generated struct
 FieldType          // specify field type
 FieldTypeReg       // specify field type (match with regexp)
 FieldTag           // specify gorm and json tag

--- a/field_options.go
+++ b/field_options.go
@@ -59,6 +59,15 @@ var (
 			}
 			return m
 		}
+	} // FieldComment specify field comment in generated struct
+	FieldComment = func(columnName string, comment string) model.ModifyFieldOpt {
+		return func(m *model.Field) *model.Field {
+			if m.ColumnName == columnName {
+				m.ColumnComment = comment
+				m.MultilineComment = strings.Contains(comment, "\n")
+			}
+			return m
+		}
 	}
 	// FieldType specify field type in generated struct
 	FieldType = func(columnName string, newType string) model.ModifyFieldOpt {

--- a/field_options.go
+++ b/field_options.go
@@ -59,7 +59,8 @@ var (
 			}
 			return m
 		}
-	} // FieldComment specify field comment in generated struct
+	}
+	// FieldComment specify field comment in generated struct
 	FieldComment = func(columnName string, comment string) model.ModifyFieldOpt {
 		return func(m *model.Field) *model.Field {
 			if m.ColumnName == columnName {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [ ] Tested

it looks like all `gen.Field...` are not tested?

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

close https://github.com/go-gorm/gen/issues/485


```golang
	g.ApplyBasic(g.GenerateModelAs("chii_groups", "Group",
		gen.FieldComment("grp_lastpost", "always 0"),
	))
```

generate struct like this:

```golang
type Group struct {
	GrpLastpost uint32        `gorm:"..."` // always 0
}
```