### PR TITLE
feat: add imports from DIY interface package to accelerate imports.Process

### DIFF
--- a/internal/parser/utils.go
+++ b/internal/parser/utils.go
@@ -29,3 +29,11 @@ func getParamList(fields *ast.FieldList) []Param {
 	}
 	return pars
 }
+
+func fixParamPackagePath(imports map[string]string, params []Param) {
+	for i := range params {
+		if importPath, exist := imports[params[i].Package]; exist {
+			params[i].PkgPath = importPath
+		}
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Generator prints file with a call to golang.org/x/tools/imports.Process, which will guess missing imports for source file. If import statements are already specified, The time cost of imports.Process can be greatly reduced.

This PR copies all imports used in DIY interface method parameter type to the generated file header.

### User Case Description

<!-- Your use case -->
