### PR TITLE
fix byte slice column type

### DIFF
--- a/internal/check/checkstruct.go
+++ b/internal/check/checkstruct.go
@@ -71,7 +71,7 @@ func (b *BaseStruct) getFieldRealType(f reflect.Type) string {
 		return "time.Time"
 	}
 	if f.String() == "[]uint8" || f.String() == "json.RawMessage" {
-		return "bytes"
+		return "[]byte"
 	}
 	return f.Kind().String()
 }

--- a/internal/model/base.go
+++ b/internal/model/base.go
@@ -181,7 +181,7 @@ func (m *Field) GenType() string {
 		return strings.Title(typ)
 	case "time.Time":
 		return "Time"
-	case "json.RawMessage":
+	case "json.RawMessage", "[]byte":
 		return "Bytes"
 	default:
 		return "Field"

--- a/internal/model/base.go
+++ b/internal/model/base.go
@@ -164,6 +164,7 @@ func (m *Field) Tags() string {
 
 func (m *Field) IsRelation() bool { return m.Relation != nil }
 
+// GenType return query Field.
 func (m *Field) GenType() string {
 	if m.IsRelation() {
 		return m.Type

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -206,7 +206,7 @@ func (p *Param) TmplString() string {
 
 func (p *Param) AllowType() bool {
 	switch p.Type {
-	case "string", "bytes":
+	case "string", "bytes", "[]byte":
 		return true
 	case "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64":
 		return true


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->
close https://github.com/go-gorm/gen/issues/496

- [X] Do only one thing
- [ ] Non breaking API changes (not sure about this)
- [x] Tested

### What did this pull request do?

`gen.FieldType("...", "[]byte")` will generate query field `field.NewBytes` (`[]byte`) instead of `field.NewField`  (`driver.Valuer`)
<!--
provide a general description of the code changes in your pull request
-->

https://github.com/go-gorm/gen/blob/37a8cdeb26285e884b7fd7f678ed3551f9851f87/internal/model/base.go#L173-L177

`bytes` is not a go built-in type.

### User Case Description

<!-- Your use case -->
