### PR TITLE
fix: generate unit test for custom method with non basic type

### DIFF
--- a/internal/generate/test.go
+++ b/internal/generate/test.go
@@ -29,6 +29,9 @@ func testParamToString(params []parser.Param) string {
 	for i, param := range params {
 		// TODO manage array and pointer
 		typ := param.Type
+		if param.Package != "" {
+			typ = fmt.Sprintf("%s.%s", param.Package, param.Type)
+		}
 		if param.IsArray {
 			typ = "[]" + typ
 		}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

fix unit test gen for custom method with parameter is not a basic type.

### User Case Description

<!-- Your use case -->

i have define such a method:
```go
package method

import (
	"myproject/mypackage/mytype"
	"gorm.io/gen"
)

// UserMethod ...
type UserMethod interface {

	// select * from @@table
	// where deleted_timestamp=0
	// OFFSET @listOptions.Start LIMIT @listOptions.Limit
	List(listOptions mytype.ListOptions) ([]gen.T, error)

}

```

when i try to generate unit test for this method, it gives such code:

```go
var UserListTestCase = []TestCase{}

func Test_user_List(t *testing.T) {
	user := newUser(db)
	do := user.WithContext(context.Background()).Debug()

	for i, tt := range UserListTestCase {
		t.Run("List_"+strconv.Itoa(i), func(t *testing.T) {
			res1, res2 := do.List(tt.Input.Args[0].(ListOptions))
			assert(t, "List", res1, tt.Expectation.Ret[0])
			assert(t, "List", res2, tt.Expectation.Ret[1])
		})
	}
}
```

the type assert `tt.Input.Args[0].(ListOptions) ` should be `tt.Input.Args[0].(mytype.ListOptions)`