### PR TITLE
fix: set RelationshipType from schema

### DIFF
--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -212,7 +212,7 @@ func pullRelationShip(cache map[string]bool, relationships []*schema.Relationshi
 				relationship.FieldSchema.Relationships.Many2Many...),
 			)
 		}
-		result[i] = *field.NewRelation(relationship.Name, varType, childRelations...)
+		result[i] = *field.NewRelationWithType(field.RelationshipType(relationship.Type), relationship.Name, varType, childRelations...)
 	}
 	return result
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Set `field.Relation.relationship` to the value of `schema.Relationship.Type`.

### User Case Description

When generating from model struct, generated `*Tx.Find` method on HasMany/ManyToMany Association only returns one result, due to the absense of relationship type info.

Example:

```go
package model

type A struct {
	ID uint `gorm:"primaryKey"`
}

type B struct {
	ID uint `gorm:"primaryKey"`
	A  []A  `gorm:"many2many:b_a;"`
}
// ------------------------------------
package main

// ...
func main() {
	// ...
	g.ApplyBasic(&model.A{}, &model.B{})
	g.Execute()
}
```
Before:
```go
func (a bATx) Find() (result *model.A, err error) {
	return result, a.tx.Find(&result)
}
```
After:
```go
func (a bManyToManyATx) Find() (result []*model.A, err error) {
	return result, a.tx.Find(&result)
}
```
