### PR TITLE
fix: ParseStructRelationShip with cache

### DIFF
--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -207,7 +207,7 @@ func BuildDIYMethod(f *parser.InterfaceSet, s *QueryStructMeta, data []*Interfac
 // ParseStructRelationShip parse struct's relationship
 // No one should use it directly in project
 func ParseStructRelationShip(relationship *schema.Relationships) []field.Relation {
-	cache := make(map[string]bool)
+	cache := make(map[string][]field.Relation)
 	return append(append(append(append(
 		make([]field.Relation, 0, 4),
 		pullRelationShip(cache, relationship.HasOne)...),

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -192,7 +192,7 @@ func isStructType(data reflect.Value) bool {
 		(data.Kind() == reflect.Ptr && data.Elem().Kind() == reflect.Struct)
 }
 
-func pullRelationShip(cache map[string]bool, relationships []*schema.Relationship) []field.Relation {
+func pullRelationShip(cache map[string][]field.Relation, relationships []*schema.Relationship) []field.Relation {
 	if len(relationships) == 0 {
 		return nil
 	}
@@ -200,8 +200,9 @@ func pullRelationShip(cache map[string]bool, relationships []*schema.Relationshi
 	for i, relationship := range relationships {
 		var childRelations []field.Relation
 		varType := strings.TrimLeft(relationship.Field.FieldType.String(), "[]*")
-		if !cache[varType] {
-			cache[varType] = true
+		if cacheChildRelations, ok := cache[varType]; ok {
+			childRelations = cacheChildRelations
+		} else {
 			childRelations = pullRelationShip(cache, append(append(append(append(
 				make([]*schema.Relationship, 0, 4),
 				relationship.FieldSchema.Relationships.BelongsTo...),
@@ -209,6 +210,7 @@ func pullRelationShip(cache map[string]bool, relationships []*schema.Relationshi
 				relationship.FieldSchema.Relationships.HasMany...),
 				relationship.FieldSchema.Relationships.Many2Many...),
 			)
+			cache[varType] = childRelations
 		}
 		result[i] = *field.NewRelationWithType(field.RelationshipType(relationship.Type), relationship.Name, varType, childRelations...)
 	}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

ParseStructRelationShip used the cache for the parsed structures but did not use it and skipped the child relationships.

### User Case Description

<!-- Your use case -->
