### PR TITLE
feat: escape query struct keywords

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -227,8 +227,9 @@ func (g *Generator) apply(fc interface{}, structs []*generate.QueryStructMeta) {
 
 	for _, interfaceStructMeta := range structs {
 		if g.judgeMode(WithoutContext) {
-			interfaceStructMeta.ReviseFieldName()
+			interfaceStructMeta.ReviseFieldName(model.GormKeywords)
 		}
+		interfaceStructMeta.ReviseFieldName(model.DOKeywords)
 
 		genInfo, err := g.pushQueryStructMeta(interfaceStructMeta)
 		if err != nil {

--- a/generator.go
+++ b/generator.go
@@ -227,9 +227,9 @@ func (g *Generator) apply(fc interface{}, structs []*generate.QueryStructMeta) {
 
 	for _, interfaceStructMeta := range structs {
 		if g.judgeMode(WithoutContext) {
-			interfaceStructMeta.ReviseFieldName(model.GormKeywords)
+			interfaceStructMeta.ReviseFieldNameFor(model.GormKeywords)
 		}
-		interfaceStructMeta.ReviseFieldName(model.DOKeywords)
+		interfaceStructMeta.ReviseFieldNameFor(model.DOKeywords)
 
 		genInfo, err := g.pushQueryStructMeta(interfaceStructMeta)
 		if err != nil {

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -91,9 +91,14 @@ func (b *QueryStructMeta) getFieldRealType(f reflect.Type) string {
 }
 
 // ReviseFieldName revise field name
-func (b *QueryStructMeta) ReviseFieldName(keywords model.KeyWord) {
+func (b *QueryStructMeta) ReviseFieldName() {
+	b.ReviseFieldNameFor(model.GormKeywords)
+}
+
+// ReviseFieldNameFor revise field name for keywords
+func (b *QueryStructMeta) ReviseFieldNameFor(keywords model.KeyWord) {
 	for _, m := range b.Fields {
-		m.EscapeKeyword(keywords)
+		m.EscapeKeywordFor(keywords)
 	}
 }
 

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -91,9 +91,9 @@ func (b *QueryStructMeta) getFieldRealType(f reflect.Type) string {
 }
 
 // ReviseFieldName revise field name
-func (b *QueryStructMeta) ReviseFieldName() {
+func (b *QueryStructMeta) ReviseFieldName(keywords model.KeyWord) {
 	for _, m := range b.Fields {
-		m.EscapeKeyword()
+		m.EscapeKeyword(keywords)
 	}
 }
 

--- a/internal/model/base.go
+++ b/internal/model/base.go
@@ -68,6 +68,13 @@ var GormKeywords = KeyWord{
 	},
 }
 
+// DOKeywords ...
+var DOKeywords = KeyWord{
+	words: []string{
+		"Alias", "TableName", "WithContext",
+	},
+}
+
 // GenKeywords ...
 var GenKeywords = KeyWord{
 	words: []string{
@@ -219,8 +226,8 @@ func (m *Field) GenType() string {
 }
 
 // EscapeKeyword escape keyword
-func (m *Field) EscapeKeyword() *Field {
-	if GormKeywords.FullMatch(m.Name) {
+func (m *Field) EscapeKeyword(keywords KeyWord) *Field {
+	if keywords.FullMatch(m.Name) {
 		m.Name += "_"
 	}
 	return m

--- a/internal/model/base.go
+++ b/internal/model/base.go
@@ -226,7 +226,12 @@ func (m *Field) GenType() string {
 }
 
 // EscapeKeyword escape keyword
-func (m *Field) EscapeKeyword(keywords KeyWord) *Field {
+func (m *Field) EscapeKeyword() *Field {
+	return m.EscapeKeywordFor(GormKeywords)
+}
+
+// EscapeKeywordFor escape for specified keyword
+func (m *Field) EscapeKeywordFor(keywords KeyWord) *Field {
 	if keywords.FullMatch(m.Name) {
 		m.Name += "_"
 	}

--- a/tests/.expect/dal_1/model/people.gen.go
+++ b/tests/.expect/dal_1/model/people.gen.go
@@ -16,6 +16,7 @@ const TableNamePerson = "people"
 type Person struct {
 	ID             int64          `gorm:"column:id;primaryKey;autoIncrement:true" json:"id"`
 	Name           string         `gorm:"column:name" json:"name"`
+	Alias_         string         `gorm:"column:alias" json:"alias"`
 	Age            int32          `gorm:"column:age" json:"age"`
 	Flag           bool           `gorm:"column:flag" json:"flag"`
 	AnotherFlag    int32          `gorm:"column:another_flag" json:"another_flag"`

--- a/tests/.expect/dal_1/query/people.gen.go
+++ b/tests/.expect/dal_1/query/people.gen.go
@@ -29,6 +29,7 @@ func newPerson(db *gorm.DB) person {
 	_person.ALL = field.NewAsterisk(tableName)
 	_person.ID = field.NewInt64(tableName, "id")
 	_person.Name = field.NewString(tableName, "name")
+	_person.Alias_ = field.NewString(tableName, "alias")
 	_person.Age = field.NewInt32(tableName, "age")
 	_person.Flag = field.NewBool(tableName, "flag")
 	_person.AnotherFlag = field.NewInt32(tableName, "another_flag")
@@ -59,6 +60,7 @@ type person struct {
 	ALL            field.Asterisk
 	ID             field.Int64
 	Name           field.String
+	Alias_         field.String
 	Age            field.Int32
 	Flag           field.Bool
 	AnotherFlag    field.Int32
@@ -95,6 +97,7 @@ func (p *person) updateTableName(table string) *person {
 	p.ALL = field.NewAsterisk(table)
 	p.ID = field.NewInt64(table, "id")
 	p.Name = field.NewString(table, "name")
+	p.Alias_ = field.NewString(table, "alias")
 	p.Age = field.NewInt32(table, "age")
 	p.Flag = field.NewBool(table, "flag")
 	p.AnotherFlag = field.NewInt32(table, "another_flag")
@@ -135,9 +138,10 @@ func (p *person) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (p *person) fillFieldMap() {
-	p.fieldMap = make(map[string]field.Expr, 20)
+	p.fieldMap = make(map[string]field.Expr, 21)
 	p.fieldMap["id"] = p.ID
 	p.fieldMap["name"] = p.Name
+	p.fieldMap["alias"] = p.Alias_
 	p.fieldMap["age"] = p.Age
 	p.fieldMap["flag"] = p.Flag
 	p.fieldMap["another_flag"] = p.AnotherFlag

--- a/tests/.expect/dal_2/model/people.gen.go
+++ b/tests/.expect/dal_2/model/people.gen.go
@@ -16,6 +16,7 @@ const TableNamePerson = "people"
 type Person struct {
 	ID             int64          `gorm:"column:id;primaryKey;autoIncrement:true" json:"-"`
 	Name           *string        `gorm:"column:name" json:"-"`
+	Alias_         *string        `gorm:"column:alias" json:"-"`
 	Age            *int32         `gorm:"column:age" json:"-"`
 	Flag           *bool          `gorm:"column:flag" json:"-"`
 	AnotherFlag    *int32         `gorm:"column:another_flag" json:"-"`

--- a/tests/.expect/dal_2/query/people.gen.go
+++ b/tests/.expect/dal_2/query/people.gen.go
@@ -29,6 +29,7 @@ func newPerson(db *gorm.DB) person {
 	_person.ALL = field.NewAsterisk(tableName)
 	_person.ID = field.NewInt64(tableName, "id")
 	_person.Name = field.NewString(tableName, "name")
+	_person.Alias_ = field.NewString(tableName, "alias")
 	_person.Age = field.NewInt32(tableName, "age")
 	_person.Flag = field.NewBool(tableName, "flag")
 	_person.AnotherFlag = field.NewInt32(tableName, "another_flag")
@@ -59,6 +60,7 @@ type person struct {
 	ALL            field.Asterisk
 	ID             field.Int64
 	Name           field.String
+	Alias_         field.String
 	Age            field.Int32
 	Flag           field.Bool
 	AnotherFlag    field.Int32
@@ -95,6 +97,7 @@ func (p *person) updateTableName(table string) *person {
 	p.ALL = field.NewAsterisk(table)
 	p.ID = field.NewInt64(table, "id")
 	p.Name = field.NewString(table, "name")
+	p.Alias_ = field.NewString(table, "alias")
 	p.Age = field.NewInt32(table, "age")
 	p.Flag = field.NewBool(table, "flag")
 	p.AnotherFlag = field.NewInt32(table, "another_flag")
@@ -135,9 +138,10 @@ func (p *person) GetFieldByName(fieldName string) (field.OrderExpr, bool) {
 }
 
 func (p *person) fillFieldMap() {
-	p.fieldMap = make(map[string]field.Expr, 20)
+	p.fieldMap = make(map[string]field.Expr, 21)
 	p.fieldMap["id"] = p.ID
 	p.fieldMap["name"] = p.Name
+	p.fieldMap["alias"] = p.Alias_
 	p.fieldMap["age"] = p.Age
 	p.fieldMap["flag"] = p.Flag
 	p.fieldMap["another_flag"] = p.AnotherFlag

--- a/tests/tables.sql
+++ b/tests/tables.sql
@@ -51,6 +51,7 @@ DROP TABLE IF EXISTS `people`;
 CREATE TABLE `people` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
+  `alias` varchar(255) DEFAULT NULL,
   `age` int(11) unsigned DEFAULT NULL,
   `flag` tinyint(1) DEFAULT NULL,
   `another_flag` tinyint(4) DEFAULT NULL,


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
* add `func (b *QueryStructMeta) ReviseFieldNameFor(keywords model.KeyWord)` that could specify keyword list
* add a new KeyWord `DOKeywords` contains `Alias, TableName, WithContext`
* apply `DOKeywords` every time call `(g *Generator) apply`


### User Case Description

<!-- Your use case -->
I have field named `alias` in my table, and it could not compile after generating query (conflict with `func Alias`).
Of course I could add things like `gen.FieldRename("alias", "ALIAS")` in my generating code, but I think it should work out of box.