### PR TITLE
fix: type tag closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ _testmain.go
 /.vscode
 __debug_bin
 /test/
-
+/vendor
 *.db

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -26,8 +26,18 @@ func getFields(db *gorm.DB, conf *model.Config, columns []*model.Column) (fields
 		if filterField(m, conf.FilterOpts) == nil {
 			continue
 		}
-		if t, ok := col.ColumnType.ColumnType(); ok && !conf.FieldWithTypeTag { // remove type tag if FieldWithTypeTag == false
-			m.GORMTag = strings.ReplaceAll(m.GORMTag, ";type:"+t, "")
+
+		// remove type tag if FieldWithTypeTag == false
+		if !conf.FieldWithTypeTag {
+			var tags = strings.Split(m.GORMTag, ";")
+			var newTags []string
+			for _, tag := range tags {
+				tag = strings.TrimSpace(tag)
+				if !strings.HasPrefix(tag, "type:") {
+					newTags = append(newTags, tag)
+				}
+			}
+			m.GORMTag = strings.Join(newTags, ";")
 		}
 
 		m = modifyField(m, conf.ModifyOpts)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

- 删除生成model的所有type tag

### User Case Description


- 通过postgresql源生成的model，即使`FieldWithTypeTag`关闭，也会生成type tag
- 带上type tag的model，在使用sqlite driver的时候，数据类型不兼容
- 详情请看描述：https://github.com/go-gorm/gen/issues/638
