### PR TITLE
Add the TableCount method

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,9 @@
 ---
-name: 🐛  Report a bug
-about: Your issue may already be reported! please search on the https://github.com/go-gorm/gorm/issues before creating one 🥳
+name: 🐛 Report a bug
+about: Your issue may already be reported! please search on the https://github.com/go-gorm/gorm/issues before creating
+one 🥳
 labels: type:bug
-assignees: riverchu 
+assignees: riverchu
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: 🍻  Feature request
+name: 🍻 Feature request
 about: Suggest an idea, Pull Request welcome 🚀
 labels: type:feature
 assignees: riverchu

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,5 +1,5 @@
 ---
-name: 💬  Question
+name: 💬 Question
 about: The resources of the GORM team are limited, please search documents/google/issues/test cases before ask 🙏
 labels: type:question
 assignees: riverchu

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,5 @@
 name: reviewdog
-on: [pull_request]
+on: [ pull_request ]
 jobs:
   golangci-lint:
     name: runner / golangci-lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,34 +13,34 @@ jobs:
   tests:
     strategy:
       matrix:
-        go: ['1.19', '1.18', '1.17', '1.16']
-        platform: [ubuntu-latest] # can not run in windows OS
+        go: [ '1.19', '1.18', '1.17', '1.16' ]
+        platform: [ ubuntu-latest ] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
 
-    - name: go mod package cache
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('go.sum') }}
+      - name: go mod package cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('go.sum') }}
 
-    - name: Tests
-      run: go test ./...
+      - name: Tests
+        run: go test ./...
 
   mysql:
     strategy:
       matrix:
-        dbversion: ['mysql:5.7', 'mysql:latest']
-        go: ['1.19', '1.18', '1.17', '1.16']
-        platform: [ubuntu-latest]
+        dbversion: [ 'mysql:5.7', 'mysql:latest' ]
+        go: [ '1.19', '1.18', '1.17', '1.16' ]
+        platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
 
     services:
@@ -62,24 +62,24 @@ jobs:
           --name mysql_server
 
     steps:
-    - name: Change MySQL sql_mode
-      run: docker exec mysql_server mysql -uroot -p123456 -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';"
+      - name: Change MySQL sql_mode
+        run: docker exec mysql_server mysql -uroot -p123456 -e "SET GLOBAL sql_mode = 'NO_ENGINE_SUBSTITUTION';"
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
 
 
-    - name: go mod package cache
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('tests/go.mod') }}
+      - name: go mod package cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('tests/go.mod') }}
 
-    - name: Tests
-      run: GITHUB_ACTION=true GORM_DIALECT=mysql GORM_DSN="gen:gen@tcp(localhost:9910)/gen?charset=utf8&parseTime=True" ./tests/test.sh
+      - name: Tests
+        run: GITHUB_ACTION=true GORM_DIALECT=mysql GORM_DSN="gen:gen@tcp(localhost:9910)/gen?charset=utf8&parseTime=True" ./tests/test.sh
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters-settings:
   unused:
     check-exported: false
   revive:
-      min-confidence: 0.8
+    min-confidence: 0.8
 
 linters:
   presets:

--- a/README.ZH_CN.md
+++ b/README.ZH_CN.md
@@ -27,107 +27,107 @@
 ## <span id="contents">目录</span>
 
 - [GORM/GEN](#gormgen)
-  - [更多语言版本的 README](#multilingual-readme)
-  - [概览](#overview)
-  - [目录](#contents)
-  - [安装](#installation)
-  - [快速开始](#quick-start)
-    - [项目路径](#project-directory)
-  - [API 示例](#api-examples)
-    - [生成](#generate)
-      - [生成模式](#generate-mode)
-      - [模型生成](#generate-model)
-      - [类型映射](#data-mapping)
-    - [字段表达式](#field-expression)
-      - [创建字段](#create-field)
-    - [CRUD 接口](#crud-api)
-      - [创建](#create)
-        - [创建记录](#create-record)
-        - [选择字段创建](#create-record-with-selected-fields)
-        - [批量创建](#batch-insert)
-      - [查询](#query)
-        - [单条数据](#retrieving-a-single-object)
-        - [根据主键查询数据](#retrieving-objects-with-primary-key)
-        - [查询所有数据](#retrieving-all-objects)
-        - [条件查询](#conditions)
-          - [字符串和基础查询套件](#string-conditions)
-          - [内联条件查询](#inline-condition)
-          - [取反（not）查询](#not-conditions)
-          - [或（or）查询](#or-conditions)
-          - [组合查询](#group-conditions)
-          - [指定字段查询](#selecting-specific-fields)
-          - [元组查询](#tuple-query)
-          - [JSON 查询](#json-query)
-          - [Order 排序](#order)
-          - [分页查询(Limit & Offset)](#limit--offset)
-          - [分组查询（Group By & Having）](#group-by--having)
-          - [去重（Distinct）](#distinct)
-          - [联表查询（Joins）](#joins)
-        - [子查询](#subquery)
-          - [From 子查询](#from-subquery)
-          - [从子查询更新](#update-from-subquery)
-          - [从子查询更新多个字段](#update-multiple-columns-from-subquery)
-        - [事务](#transaction)
-          - [嵌套事务](#nested-transactions)
-          - [手动事务](#transactions-by-manual)
-          - [保存点/回滚](#savepointrollbackto)
-        - [高级查询](#advanced-query)
-          - [迭代](#iteration)
-          - [批量查询](#findinbatches)
-          - [Pluck 方法](#pluck)
-          - [Scopes 查询](#scopes)
-          - [Count 计数](#count)
-          - [首条匹配或指定查询实例初始化条件（FirstOrInit）](#firstorinit)
-          - [首条匹配或指定创建实例初始化条件（FirstOrCreate）](#firstorcreate)
-      - [关联关系（Association）](#association)
-        - [关联](#relation)
-          - [关联已存在的模型](#relate-to-exist-model)
-          - [和数据库表关联](#relate-to-table-in-database)
-          - [关联配置](#relate-config)
-        - [操作](#operation)
-          - [跳过自动创建关联](#skip-auto-createupdate)
-          - [查询关联](#find-associations)
-          - [添加关联](#append-associations)
-          - [替换关联](#replace-associations)
-          - [删除关联](#delete-associations)
-          - [清除关联](#clear-associations)
-          - [统计关联](#count-associations)
-          - [删除指定关联](#delete-with-select)
-        - [预加载](#preloading)
-          - [预加载（Preload）](#preload)
-          - [预加载全部数据（Preload All）](#preload-all)
-          - [预加载指定列](#preload-with-select)
-          - [根据条件预加载](#preload-with-conditions)
-          - [嵌套预加载](#nested-preloading)
-      - [更新](#update)
-        - [更新单个字段](#update-single-column)
-        - [更新多个字段](#updates-multiple-columns)
-        - [更新指定字段](#update-selected-fields)
-      - [删除](#delete)
-        - [删除记录](#delete-record)
-        - [根据主键删除](#delete-with-primary-key)
-        - [批量删除](#batch-delete)
-        - [软删除](#soft-delete)
-        - [查询包含软删除的记录](#find-soft-deleted-records)
-        - [永久删除](#delete-permanently)
-    - [自定义方法](#diy-method)
-      - [接口定义](#method-interface)
-        - [模板语法](#syntax-of-template)
-          - [占位符](#placeholder)
-          - [模板](#template)
-          - [`If` 子句](#if-clause)
-          - [`Where` 子句](#where-clause)
-          - [`Set` 子句](#set-clause)
-          - [`For` 子句](#for-clause)
-        - [方法接口示例](#method-interface-example)
-      - [单元测试](#unit-test)
-      - [智能选择字段](#smart-select-fields)
-    - [高级教程](#advanced-topics)
-      - [查询优化提示（Hints）](#hints)
-  - [二进制命令行工具安装](#binary)
-  - [维护者](#maintainers)
-  - [如何参与贡献](#contributing)
-  - [开源许可协议](#license)
+    - [更多语言版本的 README](#multilingual-readme)
+    - [概览](#overview)
+    - [目录](#contents)
+    - [安装](#installation)
+    - [快速开始](#quick-start)
+        - [项目路径](#project-directory)
+    - [API 示例](#api-examples)
+        - [生成](#generate)
+            - [生成模式](#generate-mode)
+            - [模型生成](#generate-model)
+            - [类型映射](#data-mapping)
+        - [字段表达式](#field-expression)
+            - [创建字段](#create-field)
+        - [CRUD 接口](#crud-api)
+            - [创建](#create)
+                - [创建记录](#create-record)
+                - [选择字段创建](#create-record-with-selected-fields)
+                - [批量创建](#batch-insert)
+            - [查询](#query)
+                - [单条数据](#retrieving-a-single-object)
+                - [根据主键查询数据](#retrieving-objects-with-primary-key)
+                - [查询所有数据](#retrieving-all-objects)
+                - [条件查询](#conditions)
+                    - [字符串和基础查询套件](#string-conditions)
+                    - [内联条件查询](#inline-condition)
+                    - [取反（not）查询](#not-conditions)
+                    - [或（or）查询](#or-conditions)
+                    - [组合查询](#group-conditions)
+                    - [指定字段查询](#selecting-specific-fields)
+                    - [元组查询](#tuple-query)
+                    - [JSON 查询](#json-query)
+                    - [Order 排序](#order)
+                    - [分页查询(Limit & Offset)](#limit--offset)
+                    - [分组查询（Group By & Having）](#group-by--having)
+                    - [去重（Distinct）](#distinct)
+                    - [联表查询（Joins）](#joins)
+                - [子查询](#subquery)
+                    - [From 子查询](#from-subquery)
+                    - [从子查询更新](#update-from-subquery)
+                    - [从子查询更新多个字段](#update-multiple-columns-from-subquery)
+                - [事务](#transaction)
+                    - [嵌套事务](#nested-transactions)
+                    - [手动事务](#transactions-by-manual)
+                    - [保存点/回滚](#savepointrollbackto)
+                - [高级查询](#advanced-query)
+                    - [迭代](#iteration)
+                    - [批量查询](#findinbatches)
+                    - [Pluck 方法](#pluck)
+                    - [Scopes 查询](#scopes)
+                    - [Count 计数](#count)
+                    - [首条匹配或指定查询实例初始化条件（FirstOrInit）](#firstorinit)
+                    - [首条匹配或指定创建实例初始化条件（FirstOrCreate）](#firstorcreate)
+            - [关联关系（Association）](#association)
+                - [关联](#relation)
+                    - [关联已存在的模型](#relate-to-exist-model)
+                    - [和数据库表关联](#relate-to-table-in-database)
+                    - [关联配置](#relate-config)
+                - [操作](#operation)
+                    - [跳过自动创建关联](#skip-auto-createupdate)
+                    - [查询关联](#find-associations)
+                    - [添加关联](#append-associations)
+                    - [替换关联](#replace-associations)
+                    - [删除关联](#delete-associations)
+                    - [清除关联](#clear-associations)
+                    - [统计关联](#count-associations)
+                    - [删除指定关联](#delete-with-select)
+                - [预加载](#preloading)
+                    - [预加载（Preload）](#preload)
+                    - [预加载全部数据（Preload All）](#preload-all)
+                    - [预加载指定列](#preload-with-select)
+                    - [根据条件预加载](#preload-with-conditions)
+                    - [嵌套预加载](#nested-preloading)
+            - [更新](#update)
+                - [更新单个字段](#update-single-column)
+                - [更新多个字段](#updates-multiple-columns)
+                - [更新指定字段](#update-selected-fields)
+            - [删除](#delete)
+                - [删除记录](#delete-record)
+                - [根据主键删除](#delete-with-primary-key)
+                - [批量删除](#batch-delete)
+                - [软删除](#soft-delete)
+                - [查询包含软删除的记录](#find-soft-deleted-records)
+                - [永久删除](#delete-permanently)
+        - [自定义方法](#diy-method)
+            - [接口定义](#method-interface)
+                - [模板语法](#syntax-of-template)
+                    - [占位符](#placeholder)
+                    - [模板](#template)
+                    - [`If` 子句](#if-clause)
+                    - [`Where` 子句](#where-clause)
+                    - [`Set` 子句](#set-clause)
+                    - [`For` 子句](#for-clause)
+                - [方法接口示例](#method-interface-example)
+            - [单元测试](#unit-test)
+            - [智能选择字段](#smart-select-fields)
+        - [高级教程](#advanced-topics)
+            - [查询优化提示（Hints）](#hints)
+    - [二进制命令行工具安装](#binary)
+    - [维护者](#maintainers)
+    - [如何参与贡献](#contributing)
+    - [开源许可协议](#license)
 
 ## <span id="installation">安装</span>
 
@@ -147,7 +147,8 @@ import "gorm.io/gen"
 
 ## <span id="quick-start">快速开始</span>
 
-**注意**：此处所有教程都是在 `WithContext` 模式下写的. 如果你使用的是 `WithoutContext` 模式,则可以删除所有的 `WithContext(ctx)` 代码，这样看起来会更简洁。
+**注意**：此处所有教程都是在 `WithContext` 模式下写的. 如果你使用的是 `WithoutContext`
+模式,则可以删除所有的 `WithContext(ctx)` 代码，这样看起来会更简洁。
 
 ```bash
 # assume the following code in generate.go file
@@ -293,6 +294,7 @@ FieldRelateModel   // specify relationship with exist models
 ```
 
 **生成结构体绑定自定义方法**
+
 ```Go
 type User struct{
 	ID int32
@@ -311,6 +313,7 @@ g.GenerateModel("people", gen.WithMethod(user))
 ```
 
 指定生成的查询结构体字段类型
+
 ```Go
 //package model
 type ITime struct {
@@ -453,7 +456,8 @@ u.WithContext(ctx).Omit(u.Name, u.Age).Create(&user)
 
 ##### <span id="batch-insert">批量创建</span>
 
-`Create` 方法支持批量创建记录，只需要将对应模型（Model）的切片（slice）类型数据作为参数传入即可。GORM 将生成单个 SQL 语句来插入所有数据并返回对应内容全部主键的值。
+`Create` 方法支持批量创建记录，只需要将对应模型（Model）的切片（slice）类型数据作为参数传入即可。GORM 将生成单个 SQL
+语句来插入所有数据并返回对应内容全部主键的值。
 
 ```go
 var users = []*model.User{{Name: "modi"}, {Name: "zhangqiang"}, {Name: "songyuan"}}
@@ -494,7 +498,8 @@ u.WithContext(ctx).Create(&users)
 
 ##### <span id="retrieving-a-single-object">单条数据查询</span>
 
-GROM 提供了 `First`、`Take`、`Last` 方法从数据库中查询单条数据，在查询数据库时会自动添加 `LIMIT 1` 条件，如果没有找到记录则返回错误 `ErrRecordNotFound`。
+GROM 提供了 `First`、`Take`、`Last` 方法从数据库中查询单条数据，在查询数据库时会自动添加 `LIMIT 1`
+条件，如果没有找到记录则返回错误 `ErrRecordNotFound`。
 
 ```go
 u := query.Use(db).User
@@ -711,6 +716,7 @@ users, err := u.WithContext(ctx).Order(orderCol.Desc()).Find()
 ###### <span id="limit--offset">分页查询（Limit & Offset）</span>
 
 分页查询方法，其中：
+
 * `Limit` 指定要检索的最大记录数
 * `Offset` 指定在开始返回记录之前要跳过的记录数（当前分页的位置）
 
@@ -1394,7 +1400,8 @@ u.WithContext(ctx).Omit(field.AssociationFields).Create(&user)
 // Skip all associations when creating a user
 ```
 
-方法 `Field` 会用 ''." 连接一个严谨的字段名，例如：`u.BillingAddress.Field("Address1", "Street")` 等于 `BillingAddress.Address1.Street`
+方法 `Field` 会用 ''." 连接一个严谨的字段名，例如：`u.BillingAddress.Field("Address1", "Street")`
+等于 `BillingAddress.Address1.Street`
 
 ###### <span id="find-associations">查询关联</span>
 
@@ -1660,7 +1667,8 @@ u.WithContext(ctx).Where(u.Activate.Is(true)).UpdateSimple(u.Age.Value(17), u.Nu
 // UPDATE users SET age=17, number=0, birthday=NULL, updated_at='2013-11-17 21:34:10' WHERE active=true;
 ```
 
-> **注意** 当通过 struct 更新的时候，GEN 将只会更新其非零值的字段，你可能需要用 `map` 去更新属性，或者用 `select` 去明确指定哪些字段是需要被更新的
+> **注意** 当通过 struct 更新的时候，GEN 将只会更新其非零值的字段，你可能需要用 `map` 去更新属性，或者用 `select`
+> 去明确指定哪些字段是需要被更新的
 
 ##### <span id="update-selected-fields">更新指定字段</span>
 
@@ -1728,7 +1736,8 @@ e.WithContext(ctx).Where(e.Name.Like("%modi%")).Delete()
 
 如果你的 model 中包含有 `gorm.DeletedAt` 字段，则会自动执行软删除。
 
-当使用软删除时，调用 `Delete` 不会将相关记录从数据库中删除，GORM 会将 `gorm.DeletedAt` 对应字段的值设置为当前时间，以表示删除状态和删除的时间。通过软删除的数据，无法使用普通的 Query 方法找到相应的记录。
+当使用软删除时，调用 `Delete` 不会将相关记录从数据库中删除，GORM 会将 `gorm.DeletedAt`
+对应字段的值设置为当前时间，以表示删除状态和删除的时间。通过软删除的数据，无法使用普通的 Query 方法找到相应的记录。
 
 ```go
 // Batch Delete
@@ -1772,7 +1781,8 @@ o.WithContext(ctx).Unscoped().Where(o.ID.Eq(10)).Delete()
 
 #### <span id="method-interface">接口定义</span>
 
-自定义方法，需要通过 interface 定义。在方法上通过注释的方式描述具体的 SQL 查询逻辑，简单的 WHERE 查询可以用 `where()` 包住，复杂的查询需要写完整 SQL 可以直接用 `sql()` 包住或者忽略直接写 SQL，太长的 SQL 支持换行，如果有对方法的注释，只需要在前面加一个空行。
+自定义方法，需要通过 interface 定义。在方法上通过注释的方式描述具体的 SQL 查询逻辑，简单的 WHERE 查询可以用 `where()`
+包住，复杂的查询需要写完整 SQL 可以直接用 `sql()` 包住或者忽略直接写 SQL，太长的 SQL 支持换行，如果有对方法的注释，只需要在前面加一个空行。
 
 ```go
 type Method interface {
@@ -1789,9 +1799,11 @@ type Method interface {
 }
 ```
 
-方法输入参数和返回值支持基础类型（int、string、bool等）、结构体和占位符（`gen.T`/`gen.M`/`gen.RowsAffected`）,类型支持指针和数组，返回值最多返回一个值和一个 error。
+方法输入参数和返回值支持基础类型（int、string、bool等）、结构体和占位符（`gen.T`/`gen.M`/`gen.RowsAffected`
+）,类型支持指针和数组，返回值最多返回一个值和一个 error。
 
 用法(完整case见[快速开始](#quick-start))：
+
 ```go
 // 在表user和company生成的结构体上实现model.Method中包含的方法
 g.ApplyInterface(func(method model.Method) {}, model.User{}, g.GenerateModel("company"))
@@ -1810,7 +1822,8 @@ g.ApplyInterface(func(method model.Method) {}, model.User{}, g.GenerateModel("co
 
 ###### <span id="template">模板</span>
 
-逻辑操作必须包裹在 `{{}}` 中，如 `{{if}}`，结束语句必须是 `{{end}}`，所有的语句都可以嵌套。`{{}}` 中的语法除了 `{{end}}` 其它的都是 Golang 语法。
+逻辑操作必须包裹在 `{{}}` 中，如 `{{if}}`，结束语句必须是 `{{end}}`，所有的语句都可以嵌套。`{{}}` 中的语法除了 `{{end}}`
+其它的都是 Golang 语法。
 
 - `if`/`else if`/`else` if 子句通过判断满足条件拼接字符串到SQL。
 - `where` where 子句只有在内容不为空时候插入 where，若子句的开头和结尾为 where 语句连接关键字 `AND` 或 `OR`，会将它们去除。
@@ -2001,7 +2014,8 @@ type Method interface {
 
 自定义方法的单元测试需要自定义对应的测试用例，它应该和测试文件放在同一个包里。
 
-一个测试用例包含输入和期望结果，输入应和对应的方法参数匹配，期望应和对应的方法返回值相匹配。这将在测试中被断言为 “**Equal（相等）**”。
+一个测试用例包含输入和期望结果，输入应和对应的方法参数匹配，期望应和对应的方法返回值相匹配。这将在测试中被断言为 “**
+Equal（相等）**”。
 
 ```go
 package query
@@ -2154,7 +2168,6 @@ gentool -c "./gen.yml"
 ```
 
 配置文件示例:
-
 
 config example:
 

--- a/README.md
+++ b/README.md
@@ -27,107 +27,107 @@ Gen: Friendly & Safer [GORM](https://github.com/go-gorm/gorm) powered by Code Ge
 ## Contents
 
 - [GORM/GEN](#gormgen)
-  - [Multilingual README](#multilingual-readme)
-  - [Overview](#overview)
-  - [Contents](#contents)
-  - [Installation](#installation)
-  - [Quick start](#quick-start)
-    - [Project Directory](#project-directory)
-  - [API Examples](#api-examples)
-    - [Generate](#generate)
-      - [Generate Mode](#generate-mode)
-      - [Generate Model](#generate-model)
-      - [Data Mapping](#data-mapping)
-    - [Field Expression](#field-expression)
-      - [Create Field](#create-field)
-    - [CRUD API](#crud-api)
-      - [Create](#create)
-        - [Create record](#create-record)
-        - [Create record with selected fields](#create-record-with-selected-fields)
-        - [Batch Insert](#batch-insert)
-      - [Query](#query)
-        - [Retrieving a single object](#retrieving-a-single-object)
-        - [Retrieving objects with primary key](#retrieving-objects-with-primary-key)
-        - [Retrieving all objects](#retrieving-all-objects)
-        - [Conditions](#conditions)
-          - [String Conditions](#string-conditions)
-          - [Inline Condition](#inline-condition)
-          - [Not Conditions](#not-conditions)
-          - [Or Conditions](#or-conditions)
-          - [Group Conditions](#group-conditions)
-          - [Selecting Specific Fields](#selecting-specific-fields)
-          - [Tuple Query](#tuple-query)
-          - [JSON Query](#json-query)
-          - [Order](#order)
-          - [Limit & Offset](#limit--offset)
-          - [Group By & Having](#group-by--having)
-          - [Distinct](#distinct)
-          - [Joins](#joins)
-        - [SubQuery](#subquery)
-          - [From SubQuery](#from-subquery)
-          - [Update from SubQuery](#update-from-subquery)
-          - [Update multiple columns from SubQuery](#update-multiple-columns-from-subquery)
-        - [Transaction](#transaction)
-          - [Nested Transactions](#nested-transactions)
-          - [Transactions by manual](#transactions-by-manual)
-          - [SavePoint/RollbackTo](#savepointrollbackto)
-        - [Advanced Query](#advanced-query)
-          - [Iteration](#iteration)
-          - [FindInBatches](#findinbatches)
-          - [Pluck](#pluck)
-          - [Scopes](#scopes)
-          - [Count](#count)
-          - [FirstOrInit](#firstorinit)
-          - [FirstOrCreate](#firstorcreate)
-      - [Association](#association)
-        - [Relation](#relation)
-          - [Relate to exist model](#relate-to-exist-model)
-          - [Relate to table in database](#relate-to-table-in-database)
-          - [Relate Config](#relate-config)
-        - [Operation](#operation)
-          - [Skip Auto Create/Update](#skip-auto-createupdate)
-          - [Find Associations](#find-associations)
-          - [Append Associations](#append-associations)
-          - [Replace Associations](#replace-associations)
-          - [Delete Associations](#delete-associations)
-          - [Clear Associations](#clear-associations)
-          - [Count Associations](#count-associations)
-          - [Delete with Select](#delete-with-select)
-        - [Preloading](#preloading)
-          - [Preload](#preload)
-          - [Preload All](#preload-all)
-          - [Preload with select](#preload-with-select)
-          - [Preload with conditions](#preload-with-conditions)
-          - [Nested Preloading](#nested-preloading)
-      - [Update](#update)
-        - [Update single column](#update-single-column)
-        - [Updates multiple columns](#updates-multiple-columns)
-        - [Update selected fields](#update-selected-fields)
-      - [Delete](#delete)
-        - [Delete record](#delete-record)
-        - [Delete with primary key](#delete-with-primary-key)
-        - [Batch Delete](#batch-delete)
-        - [Soft Delete](#soft-delete)
-        - [Find soft deleted records](#find-soft-deleted-records)
-        - [Delete permanently](#delete-permanently)
-    - [DIY method](#diy-method)
-      - [Method interface](#method-interface)
-        - [Syntax of template](#syntax-of-template)
-          - [placeholder](#placeholder)
-          - [template](#template)
-          - [`If` clause](#if-clause)
-          - [`Where` clause](#where-clause)
-          - [`Set` clause](#set-clause)
-          - [`For` clause](#for-clause)
-        - [Method interface example](#method-interface-example)
-      - [Unit Test](#unit-test)
-      - [Smart select fields](#smart-select-fields)
-    - [Advanced Topics](#advanced-topics)
-      - [Hints](#hints)
-  - [Binary](#binary)
-  - [Maintainers](#maintainers)
-  - [Contributing](#contributing)
-  - [License](#license)
+    - [Multilingual README](#multilingual-readme)
+    - [Overview](#overview)
+    - [Contents](#contents)
+    - [Installation](#installation)
+    - [Quick start](#quick-start)
+        - [Project Directory](#project-directory)
+    - [API Examples](#api-examples)
+        - [Generate](#generate)
+            - [Generate Mode](#generate-mode)
+            - [Generate Model](#generate-model)
+            - [Data Mapping](#data-mapping)
+        - [Field Expression](#field-expression)
+            - [Create Field](#create-field)
+        - [CRUD API](#crud-api)
+            - [Create](#create)
+                - [Create record](#create-record)
+                - [Create record with selected fields](#create-record-with-selected-fields)
+                - [Batch Insert](#batch-insert)
+            - [Query](#query)
+                - [Retrieving a single object](#retrieving-a-single-object)
+                - [Retrieving objects with primary key](#retrieving-objects-with-primary-key)
+                - [Retrieving all objects](#retrieving-all-objects)
+                - [Conditions](#conditions)
+                    - [String Conditions](#string-conditions)
+                    - [Inline Condition](#inline-condition)
+                    - [Not Conditions](#not-conditions)
+                    - [Or Conditions](#or-conditions)
+                    - [Group Conditions](#group-conditions)
+                    - [Selecting Specific Fields](#selecting-specific-fields)
+                    - [Tuple Query](#tuple-query)
+                    - [JSON Query](#json-query)
+                    - [Order](#order)
+                    - [Limit & Offset](#limit--offset)
+                    - [Group By & Having](#group-by--having)
+                    - [Distinct](#distinct)
+                    - [Joins](#joins)
+                - [SubQuery](#subquery)
+                    - [From SubQuery](#from-subquery)
+                    - [Update from SubQuery](#update-from-subquery)
+                    - [Update multiple columns from SubQuery](#update-multiple-columns-from-subquery)
+                - [Transaction](#transaction)
+                    - [Nested Transactions](#nested-transactions)
+                    - [Transactions by manual](#transactions-by-manual)
+                    - [SavePoint/RollbackTo](#savepointrollbackto)
+                - [Advanced Query](#advanced-query)
+                    - [Iteration](#iteration)
+                    - [FindInBatches](#findinbatches)
+                    - [Pluck](#pluck)
+                    - [Scopes](#scopes)
+                    - [Count](#count)
+                    - [FirstOrInit](#firstorinit)
+                    - [FirstOrCreate](#firstorcreate)
+            - [Association](#association)
+                - [Relation](#relation)
+                    - [Relate to exist model](#relate-to-exist-model)
+                    - [Relate to table in database](#relate-to-table-in-database)
+                    - [Relate Config](#relate-config)
+                - [Operation](#operation)
+                    - [Skip Auto Create/Update](#skip-auto-createupdate)
+                    - [Find Associations](#find-associations)
+                    - [Append Associations](#append-associations)
+                    - [Replace Associations](#replace-associations)
+                    - [Delete Associations](#delete-associations)
+                    - [Clear Associations](#clear-associations)
+                    - [Count Associations](#count-associations)
+                    - [Delete with Select](#delete-with-select)
+                - [Preloading](#preloading)
+                    - [Preload](#preload)
+                    - [Preload All](#preload-all)
+                    - [Preload with select](#preload-with-select)
+                    - [Preload with conditions](#preload-with-conditions)
+                    - [Nested Preloading](#nested-preloading)
+            - [Update](#update)
+                - [Update single column](#update-single-column)
+                - [Updates multiple columns](#updates-multiple-columns)
+                - [Update selected fields](#update-selected-fields)
+            - [Delete](#delete)
+                - [Delete record](#delete-record)
+                - [Delete with primary key](#delete-with-primary-key)
+                - [Batch Delete](#batch-delete)
+                - [Soft Delete](#soft-delete)
+                - [Find soft deleted records](#find-soft-deleted-records)
+                - [Delete permanently](#delete-permanently)
+        - [DIY method](#diy-method)
+            - [Method interface](#method-interface)
+                - [Syntax of template](#syntax-of-template)
+                    - [placeholder](#placeholder)
+                    - [template](#template)
+                    - [`If` clause](#if-clause)
+                    - [`Where` clause](#where-clause)
+                    - [`Set` clause](#set-clause)
+                    - [`For` clause](#for-clause)
+                - [Method interface example](#method-interface-example)
+            - [Unit Test](#unit-test)
+            - [Smart select fields](#smart-select-fields)
+        - [Advanced Topics](#advanced-topics)
+            - [Hints](#hints)
+    - [Binary](#binary)
+    - [Maintainers](#maintainers)
+    - [Contributing](#contributing)
+    - [License](#license)
 
 ## Installation
 
@@ -147,7 +147,9 @@ import "gorm.io/gen"
 
 ## Quick start
 
-**Emphasis**: All use cases in this doc are generated under `WithContext` mode. And if you generate code under `WithoutContext` mode, please remove `WithContext(ctx)` before you call any query method, it helps you make code more concise.
+**Emphasis**: All use cases in this doc are generated under `WithContext` mode. And if you generate code
+under `WithoutContext` mode, please remove `WithContext(ctx)` before you call any query method, it helps you make code
+more concise.
 
 ```bash
 # assume the following code in generate.go file
@@ -238,10 +240,10 @@ demo
 
 ```go
  g := gen.NewGenerator(gen.Config{
-        ...
-        Mode: gen.WithoutContext|gen.WithDefaultQuery|gen.WithQueryInterface,
-        ...
- })
+...
+Mode: gen.WithoutContext|gen.WithDefaultQuery|gen.WithQueryInterface,
+...
+})
 ```
 
 - `WithDefaultQuery` generate default query struct
@@ -287,19 +289,20 @@ FieldTrimSuffix    // trim column suffix
 FieldAddPrefix     // add prefix to struct field's name
 FieldAddSuffix     // add suffix to struct field's name
 FieldRelate        // specify relationship with other tables
-FieldRelateModel   // specify relationship with exist models
+FieldRelateModel // specify relationship with exist models
 ```
 
 Generate model bind custom method
+
 ```Go
 type User struct{
-	ID int32
+ID int32
 }
 func (u *User)IsEmpty()bool{
-    if u == nil {
-    return true
-    }
-    return u.ID == 0
+if u == nil {
+return true
+}
+return u.ID == 0
 }
 user := User{}
 // add custom method to generated model struct
@@ -309,27 +312,28 @@ g.GenerateModel("people", gen.WithMethod(user))
 ```
 
 Generate model with custom gen type
+
 ```Go
 //package model
 type ITime struct {
-    time.Time
+time.Time
 }
 
 // custom field type and gen type for table
-g.ApplyBasic(g.GenerateModel("people", gen.FieldType("create_time","model.ITime"), gen.FieldGenType("create_time","Time")))
+g.ApplyBasic(g.GenerateModel("people", gen.FieldType("create_time", "model.ITime"), gen.FieldGenType("create_time", "Time")))
 
 //package model
 type User struct {
-  ID int64
-  Name string
-  CreateTime ITime
+ID int64
+Name string
+CreateTime ITime
 }
 
 func (u User) GetFieldGenType(f *schema.Field) string {
-  if f.Name == "CreateTime" {
-    return "Time"
-  }
-  return ""
+if f.Name == "CreateTime" {
+return "Time"
+}
+return ""
 }
 // custom field gen type for struct
 g.ApplyBasic(model.User{})
@@ -340,15 +344,15 @@ g.ApplyBasic(model.User{})
 Specify data mapping relationship to be whatever you want.
 
 ```go
-dataMap := map[string]func(detailType string) (dataType string){
-  "int": func(detailType string) (dataType string) { return "int64" },
-  // bool mapping
-  "tinyint": func(detailType string) (dataType string) {
-    if strings.HasPrefix(detailType, "tinyint(1)") {
-      return "bool"
-    }
-    return "int8"
-  },
+dataMap := map[string]func (detailType string) (dataType string){
+"int": func (detailType string) (dataType string) { return "int64" },
+// bool mapping
+"tinyint": func (detailType string) (dataType string) {
+if strings.HasPrefix(detailType, "tinyint(1)") {
+return "bool"
+}
+return "int8"
+},
 }
 
 g.WithDataTypeMap(dataMap)
@@ -451,14 +455,15 @@ u.WithContext(ctx).Omit(u.Name, u.Age).Create(&user)
 
 ##### Batch Insert
 
-To efficiently insert large number of records, pass a slice to the `Create` method. GORM will generate a single SQL statement to insert all the data and backfill primary key values.
+To efficiently insert large number of records, pass a slice to the `Create` method. GORM will generate a single SQL
+statement to insert all the data and backfill primary key values.
 
 ```go
 var users = []*model.User{{Name: "modi"}, {Name: "zhangqiang"}, {Name: "songyuan"}}
 query.Use(db).User.WithContext(ctx).Create(users...)
 
 for _, user := range users {
-    user.ID // 1,2,3
+user.ID // 1,2,3
 }
 ```
 
@@ -475,7 +480,7 @@ It will works if you set `CreateBatchSize` in `gorm.Config` / `gorm.Session`
 
 ```go
 db, err := gorm.Open(sqlite.Open("gorm.db"), &gorm.Config{
-    CreateBatchSize: 1000,
+CreateBatchSize: 1000,
 })
 // OR
 db = db.Session(&gorm.Session{CreateBatchSize: 1000})
@@ -492,7 +497,8 @@ u.WithContext(ctx).Create(&users)
 
 ##### Retrieving a single object
 
-Generated code provides `First`, `Take`, `Last` methods to retrieve a single object from the database, it adds `LIMIT 1` condition when querying the database, and it will return the error `ErrRecordNotFound` if no record is found.
+Generated code provides `First`, `Take`, `Last` methods to retrieve a single object from the database, it adds `LIMIT 1`
+condition when querying the database, and it will return the error `ErrRecordNotFound` if no record is found.
 
 ```go
 u := query.Use(db).User
@@ -521,7 +527,7 @@ u := query.Use(db).User
 user, err := u.WithContext(ctx).Where(u.ID.Eq(10)).First()
 // SELECT * FROM users WHERE id = 10;
 
-users, err := u.WithContext(ctx).Where(u.ID.In(1,2,3)).Find()
+users, err := u.WithContext(ctx).Where(u.ID.In(1, 2,3)).Find()
 // SELECT * FROM users WHERE id IN (1,2,3);
 ```
 
@@ -610,7 +616,7 @@ users, err := u.WithContext(ctx).Not(u.Name.In("modi", "zhangqiang")).Find()
 // SELECT * FROM users WHERE name NOT IN ("modi", "zhangqiang");
 
 // Not In slice of primary keys
-user, err := u.WithContext(ctx).Not(u.ID.In(1,2,3)).First()
+user, err := u.WithContext(ctx).Not(u.ID.In(1, 2, 3)).First()
 // SELECT * FROM users WHERE id NOT IN (1,2,3) ORDER BY id LIMIT 1;
 ```
 
@@ -632,10 +638,10 @@ p := query.Use(db).Pizza
 pd := p.WithContext(ctx)
 
 pizzas, err := pd.Where(
-    pd.Where(p.Pizza.Eq("pepperoni")).
-        Where(pd.Where(p.Size.Eq("small")).Or(p.Size.Eq("medium"))),
+pd.Where(p.Pizza.Eq("pepperoni")).
+Where(pd.Where(p.Size.Eq("small")).Or(p.Size.Eq("medium"))),
 ).Or(
-    pd.Where(p.Pizza.Eq("hawaiian")).Where(p.Size.Eq("xlarge")),
+pd.Where(p.Pizza.Eq("hawaiian")).Where(p.Size.Eq("xlarge")),
 ).Find()
 
 // SELECT * FROM `pizzas` WHERE (pizza = "pepperoni" AND (size = "small" OR size = "medium")) OR (pizza = "hawaiian" AND size = "xlarge")
@@ -643,7 +649,8 @@ pizzas, err := pd.Where(
 
 ###### Selecting Specific Fields
 
-`Select` allows you to specify the fields that you want to retrieve from database. Otherwise, GORM will select all fields by default.
+`Select` allows you to specify the fields that you want to retrieve from database. Otherwise, GORM will select all
+fields by default.
 
 ```go
 u := query.Use(db).User
@@ -695,7 +702,7 @@ u := query.Use(db).User
 
 orderCol, ok := u.GetFieldByName(orderColStr) // maybe orderColStr == "id"
 if !ok {
-  // User doesn't contains orderColStr
+// User doesn't contains orderColStr
 }
 
 users, err := u.WithContext(ctx).Order(orderCol).Find()
@@ -738,8 +745,8 @@ users, err := u.WithContext(ctx).Offset(10).Offset(-1).Find()
 u := query.Use(db).User
 
 var users []struct {
-    Name  string
-    Total int
+Name  string
+Total int
 }
 err := u.WithContext(ctx).Select(u.Name, u.ID.Count().As("total")).Group(u.Name).Scan(&users)
 // SELECT name, count(id) as total FROM `users` GROUP BY `name`
@@ -752,19 +759,19 @@ err := u.WithContext(ctx).Select(u.Name, u.Age.Sum().As("total")).Group(u.Name).
 
 rows, err := u.WithContext(ctx).Select(u.Birthday.As("date"), u.Age.Sum().As("total")).Group(u.Birthday).Rows()
 for rows.Next() {
-  ...
+...
 }
 
 o := query.Use(db).Order
 
 rows, err := o.WithContext(ctx).Select(o.CreateAt.Date().As("date"), o.Amount.Sum().As("total")).Group(o.CreateAt.Date()).Having(u.Amount.Sum().Gt(100)).Rows()
 for rows.Next() {
-  ...
+...
 }
 
 var results []struct {
-    Date  time.Time
-    Total int
+Date  time.Time
+Total int
 }
 
 o.WithContext(ctx).Select(o.CreateAt.Date().As("date"), o.WithContext(ctx).Amount.Sum().As("total")).Group(o.CreateAt.Date()).Having(u.Amount.Sum().Gt(100)).Scan(&results)
@@ -793,9 +800,9 @@ e := q.Email
 c := q.CreditCard
 
 type Result struct {
-    Name  string
-    Email string
-    ID    int64
+Name  string
+Email string
+ID    int64
 }
 
 var result Result
@@ -817,7 +824,7 @@ err := u.WithContext(ctx).Select(u.Name, e2.Email).LeftJoin(e.WithContext(ctx).S
 
 rows, err := u.WithContext(ctx).Select(u.Name, e.Email).LeftJoin(e, e.UserID.EqCol(u.ID)).Rows()
 for rows.Next() {
-  ...
+...
 }
 
 var results []Result
@@ -914,38 +921,39 @@ To perform a set of operations within a transaction, the general flow is as belo
 ```go
 q := query.Use(db)
 
-q.Transaction(func(tx *query.Query) error {
-  if _, err := tx.User.WithContext(ctx).Where(tx.User.ID.Eq(100)).Delete(); err != nil {
-    return err
-  }
-  if _, err := tx.Article.WithContext(ctx).Create(&model.User{Name:"modi"}); err != nil {
-    return err
-  }
-  return nil
+q.Transaction(func (tx *query.Query) error {
+if _, err := tx.User.WithContext(ctx).Where(tx.User.ID.Eq(100)).Delete(); err != nil {
+return err
+}
+if _, err := tx.Article.WithContext(ctx).Create(&model.User{Name:"modi"}); err != nil {
+return err
+}
+return nil
 })
 ```
 
 ###### Nested Transactions
 
-GEN supports nested transactions, you can rollback a subset of operations performed within the scope of a larger transaction, for example:
+GEN supports nested transactions, you can rollback a subset of operations performed within the scope of a larger
+transaction, for example:
 
 ```go
 q := query.Use(db)
 
-q.Transaction(func(tx *query.Query) error {
-  tx.User.WithContext(ctx).Create(&user1)
+q.Transaction(func (tx *query.Query) error {
+tx.User.WithContext(ctx).Create(&user1)
 
-  tx.Transaction(func(tx2 *query.Query) error {
-    tx2.User.WithContext(ctx).Create(&user2)
-    return errors.New("rollback user2") // Rollback user2
-  })
+tx.Transaction(func(tx2 *query.Query) error {
+tx2.User.WithContext(ctx).Create(&user2)
+return errors.New("rollback user2") // Rollback user2
+})
 
-  tx.Transaction(func(tx2 *query.Query) error {
-    tx2.User.WithContext(ctx).Create(&user3)
-    return nil
-  })
+tx.Transaction(func (tx2 *query.Query) error {
+tx2.User.WithContext(ctx).Create(&user3)
+return nil
+})
 
-  return nil
+return nil
 })
 
 // Commit user1, user3
@@ -977,18 +985,18 @@ For example:
 q := query.Use(db)
 
 func doSomething(ctx context.Context, users ...*model.User) (err error) {
-    tx := q.Begin()
-    defer func() {
-        if recover() != nil || err != nil {
-            _ = tx.Rollback()
-        }
-    }()
+tx := q.Begin()
+defer func() {
+if recover() != nil || err != nil {
+_ = tx.Rollback()
+}
+}()
 
-    err = tx.User.WithContext(ctx).Create(users...)
-    if err != nil {
-        return
-    }
-    return tx.Commit()
+err = tx.User.WithContext(ctx).Create(users...)
+if err != nil {
+return
+}
+return tx.Commit()
 }
 ```
 
@@ -1022,11 +1030,11 @@ rows, err := do.Where(u.Name.Eq("modi")).Rows()
 defer rows.Close()
 
 for rows.Next() {
-    var user User
-    // ScanRows is a method of `gorm.DB`, it can be used to scan a row into a struct
-    do.ScanRows(rows, &user)
+var user User
+// ScanRows is a method of `gorm.DB`, it can be used to scan a row into a struct
+do.ScanRows(rows, &user)
 
-    // do something
+// do something
 }
 ```
 
@@ -1057,7 +1065,8 @@ err := u.WithContext(ctx).Where(u.ID.Gt(9)).FindInBatches(&results, 100, func(tx
 
 ###### Pluck
 
-Query single column from database and scan into a slice, if you want to query multiple columns, use `Select` with `Scan` instead
+Query single column from database and scan into a slice, if you want to query multiple columns, use `Select` with `Scan`
+instead
 
 ```go
 u := query.Use(db).User
@@ -1085,21 +1094,21 @@ users, err := db.Select(u.Name, u.Age).Find()
 o := query.Use(db).Order
 
 func AmountGreaterThan1000(tx gen.Dao) gen.Dao {
-    return tx.Where(o.Amount.Gt(1000))
+return tx.Where(o.Amount.Gt(1000))
 }
 
 func PaidWithCreditCard(tx gen.Dao) gen.Dao {
-    return tx.Where(o.PayModeSign.Eq("C"))
+return tx.Where(o.PayModeSign.Eq("C"))
 }
 
 func PaidWithCod(tx gen.Dao) gen.Dao {
-    return tx.Where(o.PayModeSign.Eq("C"))
+return tx.Where(o.PayModeSign.Eq("C"))
 }
 
 func OrderStatus(status []string) func (tx gen.Dao) gen.Dao {
-    return func (tx gen.Dao) gen.Dao {
-      return tx.Where(o.Status.In(status...))
-    }
+return func (tx gen.Dao) gen.Dao {
+return tx.Where(o.Status.In(status...))
+}
 }
 
 orders, err := o.WithContext(ctx).Scopes(AmountGreaterThan1000, PaidWithCreditCard).Find()
@@ -1167,7 +1176,8 @@ user, err := u.WithContext(ctx).Where(u.Name.Eq("modi")).Attrs(u.Age.Value(20)).
 // user -> User{ID: 1, Name: "modi", Age: 17}
 ```
 
-`Assign` attributes to struct regardless it is found or not, those attributes won’t be used to build SQL query and the final data won’t be saved into database
+`Assign` attributes to struct regardless it is found or not, those attributes won’t be used to build SQL query and the
+final data won’t be saved into database
 
 ```go
 // User not found, initialize it with give conditions and Assign attributes
@@ -1243,10 +1253,10 @@ There are 4 kind of relationship.
 
 ```go
 const (
-    HasOne    RelationshipType = RelationshipType(schema.HasOne)    // HasOneRel has one relationship
-    HasMany   RelationshipType = RelationshipType(schema.HasMany)   // HasManyRel has many relationships
-    BelongsTo RelationshipType = RelationshipType(schema.BelongsTo) // BelongsToRel belongs to relationship
-    Many2Many RelationshipType = RelationshipType(schema.Many2Many) // Many2ManyRel many to many relationship
+HasOne    RelationshipType = RelationshipType(schema.HasOne)    // HasOneRel has one relationship
+HasMany   RelationshipType = RelationshipType(schema.HasMany)   // HasManyRel has many relationships
+BelongsTo RelationshipType = RelationshipType(schema.BelongsTo) // BelongsToRel belongs to relationship
+Many2Many RelationshipType = RelationshipType(schema.Many2Many) // Many2ManyRel many to many relationship
 )
 ```
 
@@ -1278,12 +1288,12 @@ g.ApplyBasic(model.Customer{}, model.CreditCard{})
 package query
 
 type customer struct {
-    ...
-    CreditCards customerHasManyCreditCards
+...
+CreditCards customerHasManyCreditCards
 }
 
 type creditCard struct{
-    ...
+...
 }
 ```
 
@@ -1293,11 +1303,11 @@ The association have to be speified by `gen.FieldRelate`
 
 ```go
 card := g.GenerateModel("credit_cards")
-customer := g.GenerateModel("customers", gen.FieldRelate(field.HasMany, "CreditCards", b, 
-    &field.RelateConfig{
-        // RelateSlice: true,
-        GORMTag: "foreignKey:CustomerRefer",
-    }),
+customer := g.GenerateModel("customers", gen.FieldRelate(field.HasMany, "CreditCards", b,
+&field.RelateConfig{
+// RelateSlice: true,
+GORMTag: "foreignKey:CustomerRefer",
+}),
 )
 
 g.ApplyBasic(card, custormer)
@@ -1308,32 +1318,32 @@ GEN will generate models with associated field:
 ```go
 // customers
 type Customer struct {
-    ID          int64          `gorm:"column:id;type:bigint(20) unsigned;primaryKey" json:"id"`
-    CreatedAt   time.Time      `gorm:"column:created_at;type:datetime(3)" json:"created_at"`
-    UpdatedAt   time.Time      `gorm:"column:updated_at;type:datetime(3)" json:"updated_at"`
-    DeletedAt   gorm.DeletedAt `gorm:"column:deleted_at;type:datetime(3)" json:"deleted_at"`
-    CreditCards []CreditCard   `gorm:"foreignKey:CustomerRefer" json:"credit_cards"`
+ID          int64          `gorm:"column:id;type:bigint(20) unsigned;primaryKey" json:"id"`
+CreatedAt   time.Time      `gorm:"column:created_at;type:datetime(3)" json:"created_at"`
+UpdatedAt   time.Time      `gorm:"column:updated_at;type:datetime(3)" json:"updated_at"`
+DeletedAt   gorm.DeletedAt `gorm:"column:deleted_at;type:datetime(3)" json:"deleted_at"`
+CreditCards []CreditCard   `gorm:"foreignKey:CustomerRefer" json:"credit_cards"`
 }
 
 
 // credit_cards
 type CreditCard struct {
-    ID            int64          `gorm:"column:id;type:bigint(20) unsigned;primaryKey" json:"id"`
-    CreatedAt     time.Time      `gorm:"column:created_at;type:datetime(3)" json:"created_at"`
-    UpdatedAt     time.Time      `gorm:"column:updated_at;type:datetime(3)" json:"updated_at"`
-    DeletedAt     gorm.DeletedAt `gorm:"column:deleted_at;type:datetime(3)" json:"deleted_at"`
-    CustomerRefer int64          `gorm:"column:customer_refer;type:bigint(20) unsigned" json:"customer_refer"`
+ID            int64          `gorm:"column:id;type:bigint(20) unsigned;primaryKey" json:"id"`
+CreatedAt     time.Time      `gorm:"column:created_at;type:datetime(3)" json:"created_at"`
+UpdatedAt     time.Time      `gorm:"column:updated_at;type:datetime(3)" json:"updated_at"`
+DeletedAt     gorm.DeletedAt `gorm:"column:deleted_at;type:datetime(3)" json:"deleted_at"`
+CustomerRefer int64          `gorm:"column:customer_refer;type:bigint(20) unsigned" json:"customer_refer"`
 }
 ```
 
 If associated model already exists, `gen.FieldRelateModel` can help you build associations between them.
 
 ```go
-customer := g.GenerateModel("customers", gen.FieldRelateModel(field.HasMany, "CreditCards", model.CreditCard{}, 
-    &field.RelateConfig{
-        // RelateSlice: true,
-        GORMTag: "foreignKey:CustomerRefer",
-    }),
+customer := g.GenerateModel("customers", gen.FieldRelateModel(field.HasMany, "CreditCards", model.CreditCard{},
+&field.RelateConfig{
+// RelateSlice: true,
+GORMTag: "foreignKey:CustomerRefer",
+}),
 )
 
 g.ApplyBasic(custormer)
@@ -1343,15 +1353,15 @@ g.ApplyBasic(custormer)
 
 ```go
 type RelateConfig struct {
-    // specify field's type
-    RelatePointer      bool // ex: CreditCard  *CreditCard
-    RelateSlice        bool // ex: CreditCards []CreditCard
-    RelateSlicePointer bool // ex: CreditCards []*CreditCard
+// specify field's type
+RelatePointer      bool // ex: CreditCard  *CreditCard
+RelateSlice        bool // ex: CreditCards []CreditCard
+RelateSlicePointer bool // ex: CreditCards []*CreditCard
 
-    JSONTag      string // related field's JSON tag
-    GORMTag      string // related field's GORM tag
-    NewTag       string // related field's new tag
-    OverwriteTag string // related field's tag
+JSONTag      string // related field's JSON tag
+GORMTag      string // related field's GORM tag
+NewTag       string // related field's new tag
+OverwriteTag string // related field's tag
 }
 ```
 
@@ -1361,17 +1371,17 @@ type RelateConfig struct {
 
 ```go
 user := model.User{
-  Name:            "modi",
-  BillingAddress:  Address{Address1: "Billing Address - Address 1"},
-  ShippingAddress: Address{Address1: "Shipping Address - Address 1"},
-  Emails:          []Email{
-    {Email: "modi@example.com"},
-    {Email: "modi-2@example.com"},
-  },
-  Languages:       []Language{
-    {Name: "ZH"},
-    {Name: "EN"},
-  },
+Name:            "modi",
+BillingAddress:  Address{Address1: "Billing Address - Address 1"},
+ShippingAddress: Address{Address1: "Shipping Address - Address 1"},
+Emails:          []Email{
+{Email: "modi@example.com"},
+{Email: "modi-2@example.com"},
+},
+Languages:       []Language{
+{Name: "ZH"},
+{Name: "EN"},
+},
 }
 
 u := query.Use(db).User
@@ -1389,7 +1399,8 @@ u.WithContext(ctx).Omit(field.AssociationFields).Create(&user)
 // Skip all associations when creating a user
 ```
 
-Method `Field` will join a serious field name with ''.", for example: `u.BillingAddress.Field("Address1", "Street")` equals to `BillingAddress.Address1.Street`
+Method `Field` will join a serious field name with ''.", for example: `u.BillingAddress.Field("Address1", "Street")`
+equals to `BillingAddress.Address1.Street`
 
 ###### Find Associations
 
@@ -1407,7 +1418,7 @@ Find associations with conditions
 q := query.Use(db)
 u := q.User
 
-languages, err = u.Languages.Where(q.Language.Name.In([]string{"ZH","EN"})).Model(&user).Find()
+languages, err = u.Languages.Where(q.Language.Name.In([]string{"ZH", "EN"})).Model(&user).Find()
 ```
 
 ###### Append Associations
@@ -1434,7 +1445,8 @@ u.Languages.Model(&user).Replace(&languageZH, &languageEN)
 
 ###### Delete Associations
 
-Remove the relationship between source & arguments if exists, only delete the reference, won’t delete those objects from DB.
+Remove the relationship between source & arguments if exists, only delete the reference, won’t delete those objects from
+DB.
 
 ```go
 u := query.Use(db).User
@@ -1462,7 +1474,8 @@ u.Languages.Model(&user).Count()
 
 ###### Delete with Select
 
-You are allowed to delete selected has one/has many/many2many relations with `Select` when deleting records, for example:
+You are allowed to delete selected has one/has many/many2many relations with `Select` when deleting records, for
+example:
 
 ```go
 u := query.Use(db).User
@@ -1516,22 +1529,24 @@ users, err := u.WithContext(ctx).Preload(u.Orders).Preload(u.Profile).Preload(u.
 
 ###### Preload All
 
-`clause.Associations` can work with `Preload` similar like `Select` when creating/updating, you can use it to `Preload` all associations, for example:
+`clause.Associations` can work with `Preload` similar like `Select` when creating/updating, you can use it to `Preload`
+all associations, for example:
 
 ```go
 type User struct {
-  gorm.Model
-  Name       string
-  CompanyID  uint
-  Company    Company
-  Role       Role
-  Orders     []Order
+gorm.Model
+Name       string
+CompanyID  uint
+Company    Company
+Role       Role
+Orders     []Order
 }
 
 users, err := u.WithContext(ctx).Preload(field.Associations).Find()
 ```
 
-`clause.Associations` won’t preload nested associations, but you can use it with [Nested Preloading](#nested-preloading) together, e.g:
+`clause.Associations` won’t preload nested associations, but you can use it with [Nested Preloading](#nested-preloading)
+together, e.g:
 
 ```go
 users, err := u.WithContext(ctx).Preload(u.Orders.OrderItems.Product).Find()
@@ -1613,7 +1628,8 @@ db.Preload(u.Orders.On(o.State.Eq("paid"))).Preload(u.Orders.OrderItems).Find(&u
 
 ##### Update single column
 
-When updating a single column with `Update`, it needs to have any conditions or it will raise error `ErrMissingWhereClause`, for example:
+When updating a single column with `Update`, it needs to have any conditions or it will raise
+error `ErrMissingWhereClause`, for example:
 
 ```go
 u := query.Use(db).User
@@ -1634,7 +1650,8 @@ u.WithContext(ctx).Where(u.Activate.Is(true)).UpdateSimple(u.Age.Zero())
 
 ##### Updates multiple columns
 
-`Updates` supports update with `struct` or `map[string]interface{}`, when updating with `struct` it will only update non-zero fields by default
+`Updates` supports update with `struct` or `map[string]interface{}`, when updating with `struct` it will only update
+non-zero fields by default
 
 ```go
 u := query.Use(db).User
@@ -1655,7 +1672,8 @@ u.WithContext(ctx).Where(u.Activate.Is(true)).UpdateSimple(u.Age.Value(17), u.Nu
 // UPDATE users SET age=17, number=0, birthday=NULL, updated_at='2013-11-17 21:34:10' WHERE active=true;
 ```
 
-> **NOTE** When update with struct, GEN will only update non-zero fields, you might want to use `map` to update attributes or use `Select` to specify fields to update
+> **NOTE** When update with struct, GEN will only update non-zero fields, you might want to use `map` to update
+> attributes or use `Select` to specify fields to update
 
 ##### Update selected fields
 
@@ -1704,7 +1722,7 @@ err                 // error
 GEN allows to delete objects using primary key(s) with inline condition, it works with numbers.
 
 ```go
-u.WithContext(ctx).Where(u.ID.In(1,2,3)).Delete()
+u.WithContext(ctx).Where(u.ID.In(1, 2, 3)).Delete()
 // DELETE FROM users WHERE id IN (1,2,3);
 ```
 
@@ -1721,9 +1739,11 @@ e.WithContext(ctx).Where(e.Name.Like("%modi%")).Delete()
 
 ##### Soft Delete
 
-If your model includes a `gorm.DeletedAt` field (which is included in `gorm.Model`), it will get soft delete ability automatically!
+If your model includes a `gorm.DeletedAt` field (which is included in `gorm.Model`), it will get soft delete ability
+automatically!
 
-When calling `Delete`, the record WON’T be removed from the database, but GORM will set the `DeletedAt`‘s value to the current time, and the data is not findable with normal Query methods anymore.
+When calling `Delete`, the record WON’T be removed from the database, but GORM will set the `DeletedAt`‘s value to the
+current time, and the data is not findable with normal Query methods anymore.
 
 ```go
 // Batch Delete
@@ -1739,9 +1759,9 @@ If you don’t want to include `gorm.Model`, you can enable the soft delete feat
 
 ```go
 type User struct {
-    ID      int
-    Deleted gorm.DeletedAt
-    Name    string
+ID      int
+Deleted gorm.DeletedAt
+Name    string
 }
 ```
 
@@ -1767,7 +1787,10 @@ o.WithContext(ctx).Unscoped().Where(o.ID.Eq(10)).Delete()
 
 #### Method interface
 
-The DIY method needs to be defined through the interface. In the method, the specific SQL query logic is described in the way of comments. Simple WHERE queries can be wrapped in `where()`. When using complex queries, you need to write complete SQL. You can directly wrap them in `sql()` or write SQL directly. If there are some comments on the method, just add a blank line comment in the middle.
+The DIY method needs to be defined through the interface. In the method, the specific SQL query logic is described in
+the way of comments. Simple WHERE queries can be wrapped in `where()`. When using complex queries, you need to write
+complete SQL. You can directly wrap them in `sql()` or write SQL directly. If there are some comments on the method,
+just add a blank line comment in the middle.
 
 ```go
 type Method interface {
@@ -1783,12 +1806,16 @@ type Method interface {
     InsertValue(age int, name string) error
 }
 ```
-Method input parameters and return values support basic types (`int`, `string`, `bool`...), struct and placeholders (`gen.T`/`gen.M`/`gen.RowsAffected`), and types support pointers and arrays. The return value is at most a value and an error.
+
+Method input parameters and return values support basic types (`int`, `string`, `bool`...), struct and
+placeholders (`gen.T`/`gen.M`/`gen.RowsAffected`), and types support pointers and arrays. The return value is at most a
+value and an error.
 
 Usage(complete case on [Quick start](#quick-start)):
+
 ```go
 // implement model.Method on table "user" and "comany"
-g.ApplyInterface(func(method model.Method) {}, model.User{}, g.GenerateModel("company"))
+g.ApplyInterface(func (method model.Method) {}, model.User{}, g.GenerateModel("company"))
 ```
 
 ##### Syntax of template
@@ -1798,7 +1825,8 @@ g.ApplyInterface(func(method model.Method) {}, model.User{}, g.GenerateModel("co
 - `gen.T` represents specified `struct` or `table`
 - `gen.M` represents `map[string]interface`
 - `gen.RowsAffected` represents SQL executed `rowsAffected` (type:int64)
-- `@@table`  represents table's name (if method's parameter doesn't contains variable `table`, GEN will generate `table` from model struct)
+- `@@table`  represents table's name (if method's parameter doesn't contains variable `table`, GEN will generate `table`
+  from model struct)
 - `@@<columnName>` represents column's name or table's name
 - `@<name>` represents normal query variable
 
@@ -1807,9 +1835,13 @@ g.ApplyInterface(func(method model.Method) {}, model.User{}, g.GenerateModel("co
 Logical operations must be wrapped in `{{}}`,and end must used `{{end}}`, All templates support nesting
 
 - `if`/`else if`/`else` the condition accept a bool parameter or operation expression which conforms to Golang syntax.
-- `where` The `where` clause will be inserted only if the child elements return something. The key word  `and` or `or`  in front of clause will be removed. And `and` will be added automatically when there is no junction keyword between query condition clause.
-- `Set` The  `set` clause will be inserted only if the child elements return something. The `,` in front of columns array will be removed.And `,` will be added automatically when there is no junction keyword between query coulmns.
-- `for` The  `for` clause traverses an array according to golang syntax and inserts its contents into SQL,supports array of struct.
+- `where` The `where` clause will be inserted only if the child elements return something. The key word  `and` or `or`
+  in front of clause will be removed. And `and` will be added automatically when there is no junction keyword between
+  query condition clause.
+- `Set` The  `set` clause will be inserted only if the child elements return something. The `,` in front of columns
+  array will be removed.And `,` will be added automatically when there is no junction keyword between query coulmns.
+- `for` The  `for` clause traverses an array according to golang syntax and inserts its contents into SQL,supports array
+  of struct.
 - `...` Coming soon
 
 ###### `If` clause
@@ -1910,6 +1942,7 @@ update @@table
 {{end}}
 where id=@id
 ```
+
 ###### `For` clause
 
 ```
@@ -1994,7 +2027,8 @@ Unit test file will be generated if `WithUnitTest` is set, which will generate u
 
 Unit test for DIY method need diy testcase, which should place in the same package with test file.
 
-A testcase contains input and expectation result, input should match the method arguments, expectation should match method return values, which will be asserted **Equal** in test.
+A testcase contains input and expectation result, input should match the method arguments, expectation should match
+method return values, which will be asserted **Equal** in test.
 
 ```go
 package query
@@ -2027,44 +2061,45 @@ Corresponding test
 ```go
 //FindById select * from @@table where id = @id
 func (s studentDo) FindById(id int64) (result *model.Student, err error) {
-    ///
+///
 }
 
 func Test_student_FindById(t *testing.T) {
-    student := newStudent(db)
-    do := student.WithContext(context.Background()).Debug()
+student := newStudent(db)
+do := student.WithContext(context.Background()).Debug()
 
-    for i, tt := range StudentFindByIdTestCase {
-        t.Run("FindById_"+strconv.Itoa(i), func(t *testing.T) {
-            res1, res2 := do.FindById(tt.Input.Args[0].(int64))
-            assert(t, "FindById", res1, tt.Expectation.Ret[0])
-            assert(t, "FindById", res2, tt.Expectation.Ret[1])
-        })
-    }
+for i, tt := range StudentFindByIdTestCase {
+t.Run("FindById_"+strconv.Itoa(i), func (t *testing.T) {
+res1, res2 := do.FindById(tt.Input.Args[0].(int64))
+assert(t, "FindById", res1, tt.Expectation.Ret[0])
+assert(t, "FindById", res2, tt.Expectation.Ret[1])
+})
+}
 }
 ```
 
 #### Smart select fields
 
-GEN allows select specific fields with `Select`, if you often use this in your application, maybe you want to define a smaller struct for API usage which can select specific fields automatically, for example:
+GEN allows select specific fields with `Select`, if you often use this in your application, maybe you want to define a
+smaller struct for API usage which can select specific fields automatically, for example:
 
 ```go
 type User struct {
-  ID     uint
-  Name   string
-  Age    int
-  Gender string
-  // hundreds of fields
+ID     uint
+Name   string
+Age    int
+Gender string
+// hundreds of fields
 }
 
 type APIUser struct {
-  ID   uint
-  Name string
+ID   uint
+Name string
 }
 
 type Method interface{
-    // select * from user
-    FindSome() ([]APIUser, error)
+// select * from user
+FindSome() ([]APIUser, error)
 }
 
 apiusers, err := u.WithContext(ctx).Limit(10).FindSome()
@@ -2075,7 +2110,8 @@ apiusers, err := u.WithContext(ctx).Limit(10).FindSome()
 
 #### Hints
 
-Optimizer hints allow to control the query optimizer to choose a certain query execution plan, GORM supports it with `gorm.io/hints`, e.g:
+Optimizer hints allow to control the query optimizer to choose a certain query execution plan, GORM supports it
+with `gorm.io/hints`, e.g:
 
 ```go
 import "gorm.io/hints"

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,13 +9,13 @@ A simple best practice of `GEN`. You can configure `TARGET_DIR` value in `genera
 ## TARGET_DIR
 
 - `gen`
-a slim quick start.
+  a slim quick start.
 
 - `ultimate`
-a ultimate quick start
+  a ultimate quick start
 
 - `sync_table`
-a quick start to show how to sync table from database.
+  a quick start to show how to sync table from database.
 
 - `without_db`
-a quick start to show how to generate code without database connection.
+  a quick start to show how to generate code without database connection.

--- a/generator.go
+++ b/generator.go
@@ -465,14 +465,14 @@ func (g *Generator) generateModelFile() error {
 		return fmt.Errorf("create model pkg path(%s) fail: %s", modelOutPath, err)
 	}
 	tableName2Structs := make(map[string][]*generate.QueryStructMeta)
-	for _, data := range g.models {
-		regex := regexp.MustCompile("[a-zA-Z]+")
-		data.FileName = regex.FindString(data.FileName)
-		data.ModelStructName = regex.FindString(data.ModelStructName)
-		data.QueryStructName = regex.FindString(data.QueryStructName)
-		data.TableName = regex.FindString(data.TableName)
+	for tableName, _ := range g.models {
+		regex := regexp.MustCompile("\\D+")
+		g.models[tableName].FileName = regex.FindString(g.models[tableName].FileName)
+		g.models[tableName].ModelStructName = regex.FindString(g.models[tableName].ModelStructName)
+		g.models[tableName].QueryStructName = regex.FindString(g.models[tableName].QueryStructName)
+		g.models[tableName].TableName = regex.FindString(g.models[tableName].TableName)
 
-		tableName2Structs[data.TableName] = append(tableName2Structs[data.TableName], data)
+		tableName2Structs[g.models[tableName].TableName] = append(tableName2Structs[g.models[tableName].TableName], g.models[tableName])
 	}
 	tableName2Struct := make(map[string]*generate.QueryStructMeta)
 	for tableName, data := range tableName2Structs {
@@ -487,10 +487,10 @@ func (g *Generator) generateModelFile() error {
 			continue
 		}
 		pool.Wait()
-		fmt.Printf("1, TableName: %s, TableCount: %d\n", data.TableName, data.TableCount)
 		go func(data *generate.QueryStructMeta) {
 			defer pool.Done()
 
+			fmt.Printf("zhangpeng-111-tableName2Struct: %+v\n", data)
 			var buf bytes.Buffer
 			err := render(tmpl.Model, &buf, data)
 			if err != nil {

--- a/generator.go
+++ b/generator.go
@@ -490,7 +490,6 @@ func (g *Generator) generateModelFile() error {
 		go func(data *generate.QueryStructMeta) {
 			defer pool.Done()
 
-			fmt.Printf("zhangpeng-111-tableName2Struct: %+v\n", data)
 			var buf bytes.Buffer
 			err := render(tmpl.Model, &buf, data)
 			if err != nil {

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"gorm.io/gorm"
@@ -35,6 +36,12 @@ func GetQueryStructMeta(db *gorm.DB, conf *model.Config) (*QueryStructMeta, erro
 	if err != nil {
 		return nil, err
 	}
+
+	regex := regexp.MustCompile("\\D+")
+	fileName = regex.FindString(fileName)
+	structName = regex.FindString(structName)
+	//meta.QueryStructName = regex.FindString(meta.QueryStructName)
+	tableName = regex.FindString(tableName)
 
 	return (&QueryStructMeta{
 		db:              db,
@@ -96,6 +103,12 @@ func GetQueryStructMetaFromObject(obj helper.Object, conf *model.Config) (*Query
 			MultilineComment: strings.Contains(field.Comment(), "\n"),
 		})
 	}
+
+	regex := regexp.MustCompile("\\D+")
+	fileName = regex.FindString(fileName)
+	structName = regex.FindString(structName)
+	//meta.QueryStructName = regex.FindString(meta.QueryStructName)
+	tableName = regex.FindString(tableName)
 
 	return &QueryStructMeta{
 		Source:          model.Object,

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -32,6 +32,7 @@ type QueryStructMeta struct {
 	QueryStructName string // internal query struct name
 	ModelStructName string // origin/model struct name
 	TableName       string // table name in db server
+	TableCount      int    // total count of tables of the same type
 	StructInfo      parser.Param
 	Fields          []*model.Field
 	Source          model.SourceCode

--- a/internal/template/model.go
+++ b/internal/template/model.go
@@ -34,6 +34,13 @@ func (*{{.ModelStructName}}) TableName() string {
     return TableName{{.ModelStructName}}
 }
 {{- end}}
+
+{{if gt .TableCount 1}}
+// TableCount {{.ModelStructName}}'s table Count
+func (*{{.ModelStructName}}) TableCount() int {
+    return {{.TableCount}}
+}
+{{end}}
 `
 
 // ModelMethod model struct DIY method

--- a/tests/tables.sql
+++ b/tests/tables.sql
@@ -4,95 +4,105 @@
 -- -------------------------------------------------------------
 
 
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT = @@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS = @@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION = @@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8mb4 */;
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+/*!40014 SET @OLD_UNIQUE_CHECKS = @@UNIQUE_CHECKS, UNIQUE_CHECKS = 0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS = @@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS = 0 */;
+/*!40101 SET @OLD_SQL_MODE = @@SQL_MODE, SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES = @@SQL_NOTES, SQL_NOTES = 0 */;
 
 
 DROP TABLE IF EXISTS `banks`;
-CREATE TABLE `banks` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `name` longtext,
-  `address` longtext,
-  `scale` bigint(20) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE `banks`
+(
+    `id`      bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `name`    longtext,
+    `address` longtext,
+    `scale`   bigint(20) DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
 
 DROP TABLE IF EXISTS `credit_cards`;
-CREATE TABLE `credit_cards` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `created_at` datetime(3) DEFAULT NULL,
-  `updated_at` datetime(3) DEFAULT NULL,
-  `deleted_at` datetime(3) DEFAULT NULL,
-  `number` longtext,
-  `customer_refer` bigint(20) unsigned DEFAULT NULL,
-  `bank_id` bigint(20) unsigned DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `idx_credit_cards_deleted_at` (`deleted_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE `credit_cards`
+(
+    `id`             bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `created_at`     datetime(3)         DEFAULT NULL,
+    `updated_at`     datetime(3)         DEFAULT NULL,
+    `deleted_at`     datetime(3)         DEFAULT NULL,
+    `number`         longtext,
+    `customer_refer` bigint(20) unsigned DEFAULT NULL,
+    `bank_id`        bigint(20) unsigned DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_credit_cards_deleted_at` (`deleted_at`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
 
 DROP TABLE IF EXISTS `customers`;
-CREATE TABLE `customers` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `created_at` datetime(3) DEFAULT NULL,
-  `updated_at` datetime(3) DEFAULT NULL,
-  `deleted_at` datetime(3) DEFAULT NULL,
-  `bank_id` bigint(20) unsigned DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `idx_customers_deleted_at` (`deleted_at`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE `customers`
+(
+    `id`         bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `created_at` datetime(3)         DEFAULT NULL,
+    `updated_at` datetime(3)         DEFAULT NULL,
+    `deleted_at` datetime(3)         DEFAULT NULL,
+    `bank_id`    bigint(20) unsigned DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_customers_deleted_at` (`deleted_at`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
 
 DROP TABLE IF EXISTS `people`;
-CREATE TABLE `people` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) DEFAULT NULL,
-  `alias` varchar(255) DEFAULT NULL,
-  `age` int(11) unsigned DEFAULT NULL,
-  `flag` tinyint(1) DEFAULT NULL,
-  `another_flag` tinyint(4) DEFAULT NULL,
-  `commit` varchar(255) DEFAULT NULL,
-  `First` tinyint(1) DEFAULT NULL,
-  `bit` bit(1) DEFAULT NULL,
-  `small` smallint(5) unsigned DEFAULT NULL,
-  `deleted_at` datetime(3) DEFAULT NULL,
-  `score` decimal(19,0) DEFAULT NULL,
-  `number` int(11) DEFAULT NULL,
-  `birth` datetime DEFAULT CURRENT_TIMESTAMP,
-  `xmlHTTPRequest` varchar(255) DEFAULT ' ',
-  `jStr` json DEFAULT NULL,
-  `geo` geometry DEFAULT NULL,
-  `mint` mediumint(9) DEFAULT NULL,
-  `blank` varchar(64) DEFAULT ' ',
-  `remark` text,
-  `long_remark` longtext,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE `people`
+(
+    `id`             bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `name`           varchar(255)         DEFAULT NULL,
+    `alias`          varchar(255)         DEFAULT NULL,
+    `age`            int(11) unsigned     DEFAULT NULL,
+    `flag`           tinyint(1)           DEFAULT NULL,
+    `another_flag`   tinyint(4)           DEFAULT NULL,
+    `commit`         varchar(255)         DEFAULT NULL,
+    `First`          tinyint(1)           DEFAULT NULL,
+    `bit`            bit(1)               DEFAULT NULL,
+    `small`          smallint(5) unsigned DEFAULT NULL,
+    `deleted_at`     datetime(3)          DEFAULT NULL,
+    `score`          decimal(19, 0)       DEFAULT NULL,
+    `number`         int(11)              DEFAULT NULL,
+    `birth`          datetime             DEFAULT CURRENT_TIMESTAMP,
+    `xmlHTTPRequest` varchar(255)         DEFAULT ' ',
+    `jStr`           json                 DEFAULT NULL,
+    `geo`            geometry             DEFAULT NULL,
+    `mint`           mediumint(9)         DEFAULT NULL,
+    `blank`          varchar(64)          DEFAULT ' ',
+    `remark`         text,
+    `long_remark`    longtext,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
 
 DROP TABLE IF EXISTS `users`;
-CREATE TABLE `users` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `created_at` datetime(3) DEFAULT NULL,
-  `name` varchar(255) DEFAULT NULL COMMENT 'oneline',
-  `address` varchar(255) DEFAULT '',
-  `register_time` datetime(3) DEFAULT NULL,
-  `alive` tinyint(1) DEFAULT NULL COMMENT 'multiline\nline1\nline2',
-  `company_id` bigint(20) unsigned DEFAULT '666',
-  `private_url` varchar(255) DEFAULT 'https://a.b.c ',
-  PRIMARY KEY (`id`),
-  KEY `idx_name` (`name`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE `users`
+(
+    `id`            bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `created_at`    datetime(3)         DEFAULT NULL,
+    `name`          varchar(255)        DEFAULT NULL COMMENT 'oneline',
+    `address`       varchar(255)        DEFAULT '',
+    `register_time` datetime(3)         DEFAULT NULL,
+    `alive`         tinyint(1)          DEFAULT NULL COMMENT 'multiline\nline1\nline2',
+    `company_id`    bigint(20) unsigned DEFAULT '666',
+    `private_url`   varchar(255)        DEFAULT 'https://a.b.c ',
+    PRIMARY KEY (`id`),
+    KEY `idx_name` (`name`) USING BTREE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
 
 
 
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+/*!40101 SET SQL_MODE = @OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS = @OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS = @OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT = @OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS = @OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION = @OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES = @OLD_SQL_NOTES */;

--- a/tools/gentool/README.ZH_CN.md
+++ b/tools/gentool/README.ZH_CN.md
@@ -2,8 +2,6 @@
 
 将Gen作为二进制的方式进行安装
 
-
-
 ## 安装
 
 ```shell
@@ -45,6 +43,7 @@
 ```
 
 #### c
+
 default ""
 可以指定配置文件gen.yml的路径。
 用配置文件来代替命令行。
@@ -62,7 +61,7 @@ default ""
 
 你可以使用GORM所有的连接。
 
- 参考：https://gorm.io/docs/connecting_to_the_database.html
+参考：https://gorm.io/docs/connecting_to_the_database.html
 
 #### fieldNullable
 
@@ -80,7 +79,7 @@ default ""
 
 默认值是数据表名称。
 
- 生成的model代码的包名称。
+生成的model代码的包名称。
 
 #### outFile
 
@@ -100,11 +99,11 @@ default ""
 
 eg :
 
-​       --tables="orders" #orders 数据表
+​ --tables="orders" #orders 数据表
 
-​       --tables="orders,users" #orders 数据表和 users数据表
+​ --tables="orders,users" #orders 数据表和 users数据表
 
-​       --tables=""          # 数据库中所有的数据表
+​ --tables=""          # 数据库中所有的数据表
 
 基于数据表生成对应的代码。
 
@@ -119,7 +118,6 @@ eg :
 Value : False / True
 
 基于数据表定义的数据类型，生成对应的数据类型
-
 
 ### 使用示例
 

--- a/tools/gentool/README.md
+++ b/tools/gentool/README.md
@@ -41,12 +41,13 @@ Install GEN as a binary tool
         detect integer field's unsigned type, adjust generated data type
 
 ```
+
 #### c
+
 default ""
 Is path for gen.yml
 Replace the command line with a configuration file
 The command line is the highest priority
-
 
 #### db
 
@@ -60,7 +61,7 @@ consult : https://gorm.io/docs/connecting_to_the_database.html
 
 You can use all gorm's dsn.
 
- consult : https://gorm.io/docs/connecting_to_the_database.html
+consult : https://gorm.io/docs/connecting_to_the_database.html
 
 #### fieldNullable
 
@@ -78,11 +79,11 @@ generate field with gorm column type tag
 
 defalut table name.
 
- generated model code's package name.
+generated model code's package name.
 
 #### outFile
 
- query code file name, default: gen.go
+query code file name, default: gen.go
 
 #### outPath
 
@@ -94,11 +95,11 @@ Value : enter the required data table or leave it blank.
 
 eg :
 
-​       --tables="orders" #orders table
+​ --tables="orders" #orders table
 
-​       --tables="orders,users" #orders table and users table
+​ --tables="orders,users" #orders table and users table
 
-​       --tables=""          # All data tables in the database.
+​ --tables=""          # All data tables in the database.
 
 Generate some tables code.
 
@@ -113,8 +114,6 @@ Generate unit test.
 Value : False / True
 
 detect integer field's unsigned type, adjust generated data type
-
-
 
 ### example
 

--- a/tools/gentool/gen.yml
+++ b/tools/gentool/gen.yml
@@ -1,28 +1,28 @@
 version: "0.1"
 database:
   # consult[https://gorm.io/docs/connecting_to_the_database.html]"
-  dsn : "user:pass@tcp(127.0.0.1:3306)/dbname?charset=utf8mb4&parseTime=True&loc=Local"
+  dsn: "user:pass@tcp(127.0.0.1:3306)/dbname?charset=utf8mb4&parseTime=True&loc=Local"
   # input mysql or postgres or sqlite or sqlserver. consult[https://gorm.io/docs/connecting_to_the_database.html]
-  db  : "mysql"
+  db: "mysql"
   # enter the required data table or leave it blank.You can input : 
   # tables  : 
   #   - orders
   #   - users
   #   - goods
-  tables  :
+  tables:
   # specify a directory for output
-  outPath :  "./dao/query"
+  outPath: "./dao/query"
   # query code file name, default: gen.go
-  outFile :  ""
+  outFile: ""
   # generate unit test for query code
-  withUnitTest  : false
+  withUnitTest: false
   # generated model code's package name
-  modelPkgName  : ""
+  modelPkgName: ""
   # generate with pointer when field is nullable
-  fieldNullable : false
+  fieldNullable: false
   # generate field with gorm index tag
-  fieldWithIndexTag : false
+  fieldWithIndexTag: false
   # generate field with gorm column type tag
-  fieldWithTypeTag  : false
+  fieldWithTypeTag: false
   # detect integer field's unsigned type, adjust generated data type
-  fieldSignable  : false
+  fieldSignable: false


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Add a method(TableCount) when the number of tables in the same model is greater than 1. It is convenient for services to calculate in separate tables.

### User Case Description

<!-- Your use case -->

When I use user ids to separate the tables, I need to specify which table to add, delete, and query the users in. So I need to know which table the current user ID is in, and in this case I need to know what the sub-table logic is, such as modulo 8, modulo 10, etc. So the TableCount method is added.