### PR TITLE
fix: Can only init once for the same *gorm.DB

### DIFF
--- a/internal/template/query.go
+++ b/internal/template/query.go
@@ -20,13 +20,18 @@ func SetDefault(db *gorm.DB) {
 
 // QueryMethod query method template
 const QueryMethod = `
+var (
+	useMap = sync.Map{}
+)
+
 func Use(db *gorm.DB) *Query {
-	return &Query{
+	q, _ := useMap.LoadOrStore(db, &Query{
 		db: db,
 		{{range $name,$d :=.Data -}}
 		{{$d.ModelStructName}}: new{{$d.ModelStructName}}(db),
 		{{end -}}
-	}
+	})
+	return q.(*Query)
 }
 
 type Query struct{

--- a/tests/.expect/dal_1/query/gen.go
+++ b/tests/.expect/dal_1/query/gen.go
@@ -7,6 +7,7 @@ package query
 import (
 	"context"
 	"database/sql"
+	"sync"
 
 	"gorm.io/gorm"
 
@@ -31,15 +32,20 @@ func SetDefault(db *gorm.DB) {
 	User = &Q.User
 }
 
+var (
+	useMap = sync.Map{}
+)
+
 func Use(db *gorm.DB) *Query {
-	return &Query{
+	q, _ := useMap.LoadOrStore(db, &Query{
 		db:         db,
 		Bank:       newBank(db),
 		CreditCard: newCreditCard(db),
 		Customer:   newCustomer(db),
 		Person:     newPerson(db),
 		User:       newUser(db),
-	}
+	})
+	return q.(*Query)
 }
 
 type Query struct {

--- a/tests/.expect/dal_2/query/gen.go
+++ b/tests/.expect/dal_2/query/gen.go
@@ -7,6 +7,7 @@ package query
 import (
 	"context"
 	"database/sql"
+	"sync"
 
 	"gorm.io/gorm"
 
@@ -31,15 +32,20 @@ func SetDefault(db *gorm.DB) {
 	User = &Q.User
 }
 
+var (
+	useMap = sync.Map{}
+)
+
 func Use(db *gorm.DB) *Query {
-	return &Query{
+	q, _ := useMap.LoadOrStore(db, &Query{
 		db:         db,
 		Bank:       newBank(db),
 		CreditCard: newCreditCard(db),
 		Customer:   newCustomer(db),
 		Person:     newPerson(db),
 		User:       newUser(db),
-	}
+	})
+	return q.(*Query)
 }
 
 type Query struct {

--- a/tests/.expect/dal_test/query/gen.go
+++ b/tests/.expect/dal_test/query/gen.go
@@ -7,6 +7,7 @@ package query
 import (
 	"context"
 	"database/sql"
+	"sync"
 
 	"gorm.io/gorm"
 
@@ -31,15 +32,20 @@ func SetDefault(db *gorm.DB) {
 	User = &Q.User
 }
 
+var (
+	useMap = sync.Map{}
+)
+
 func Use(db *gorm.DB) *Query {
-	return &Query{
+	q, _ := useMap.LoadOrStore(db, &Query{
 		db:         db,
 		Bank:       newBank(db),
 		CreditCard: newCreditCard(db),
 		Customer:   newCustomer(db),
 		Person:     newPerson(db),
 		User:       newUser(db),
-	}
+	})
+	return q.(*Query)
 }
 
 type Query struct {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Fixed https://github.com/go-gorm/gen/issues/653

### User Case Description
See https://github.com/go-gorm/gen/issues/653

### Upgrade Guide
For the user who calls `query.Use()` to generate `*query.Query` before each query call, and use `Table()` method to specific table name, please consider this fix to avoid table name cache by GORM.
