### PR TITLE
fix: gentool error handling

### DIFF
--- a/README.ZH_CN.md
+++ b/README.ZH_CN.md
@@ -2165,8 +2165,13 @@ database:
   dsn : "username:password@tcp(address:port)/db?charset=utf8mb4&parseTime=true&loc=Local"
   # input mysql or postgres or sqlite or sqlserver. consult[https://gorm.io/docs/connecting_to_the_database.html]
   db  : "mysql"
-  # enter the required data table or leave it blank.You can input : orders,users,goods
-  tables  : "user"
+  # enter the required data table or leave it blank.You can input :
+  # tables  :
+  #   - orders
+  #   - users
+  #   - goods
+  tables  :
+    - "users"
   # specify a directory for output
   outPath :  "./dao/query"
   # query code file name, default: gen.go

--- a/README.md
+++ b/README.md
@@ -2177,8 +2177,13 @@ database:
   dsn : "username:password@tcp(address:port)/db?charset=utf8mb4&parseTime=true&loc=Local"
   # input mysql or postgres or sqlite or sqlserver. consult[https://gorm.io/docs/connecting_to_the_database.html]
   db  : "mysql"
-  # enter the required data table or leave it blank.You can input : orders,users,goods
-  tables  : "user"
+  # enter the required data table or leave it blank.You can input :
+  # tables  :
+  #   - orders
+  #   - users
+  #   - goods
+  tables  :
+    - "users"
   # specify a directory for output
   outPath :  "./dao/query"
   # query code file name, default: gen.go

--- a/tools/gentool/gentool.go
+++ b/tools/gentool/gentool.go
@@ -109,7 +109,7 @@ func loadConfigFile(path string) (*CmdParams, error) {
 }
 
 // argParse is parser for cmd
-func argParse() *CmdParams {
+func argParse() (*CmdParams, error) {
 	// choose is file or flag
 	genPath := flag.String("c", "", "is path for gen.yml")
 	dsn := flag.String("dsn", "", "consult[https://gorm.io/docs/connecting_to_the_database.html]")
@@ -127,7 +127,11 @@ func argParse() *CmdParams {
 	flag.Parse()
 	var cmdParse CmdParams
 	if *genPath != "" {
-		if configFileParams, err := loadConfigFile(*genPath); err == nil && configFileParams != nil {
+		configFileParams, err := loadConfigFile(*genPath)
+		if err != nil {
+			return nil, err
+		}
+		if configFileParams != nil {
 			cmdParse = *configFileParams
 		}
 	}
@@ -168,14 +172,14 @@ func argParse() *CmdParams {
 	if *fieldSignable {
 		cmdParse.FieldSignable = *fieldSignable
 	}
-	return &cmdParse
+	return &cmdParse, nil
 }
 
 func main() {
 	// cmdParse
-	config := argParse()
-	if config == nil {
-		log.Fatalln("parse config fail")
+	config, err := argParse()
+	if err != nil {
+		log.Fatalln("parse config fail\n", err)
 	}
 	db, err := connectDB(DBType(config.DB), config.DSN)
 	if err != nil {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR fixes error handling and README of gentool.
The error occurred by upgrading the version from v0.3.12 to v0.3.13 with `dsn cannot be empty` message.
I guess that this is because `table` type was changed from `string` to `[]string` in gen.yml.
(It worked well when `tables` type was `[]string` in gen.yml after upgrading v0.3.13)

I fixed two points as below.
1.  incorrect error messages to appropriate ones
2. `string` to `[]string` in config example in README

### User Case Description

<!-- Your use case -->
