### PR TITLE
When the field type is in FieldNullableList, nullable fields will be output with pointer

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,11 +35,12 @@ type Config struct {
 	WithUnitTest bool   // generate unit test for query code
 
 	// generate model global configuration
-	FieldNullable     bool // generate pointer when field is nullable
-	FieldCoverable    bool // generate pointer when field has default value, to fix problem zero value cannot be assign: https://gorm.io/docs/create.html#Default-Values
-	FieldSignable     bool // detect integer field's unsigned type, adjust generated data type
-	FieldWithIndexTag bool // generate with gorm index tag
-	FieldWithTypeTag  bool // generate with gorm column type tag
+	FieldNullable     bool     // generate pointer when field is nullable
+	FieldNullableList []string // generate pointer when field is nullable which in FieldNullableList
+	FieldCoverable    bool     // generate pointer when field has default value, to fix problem zero value cannot be assign: https://gorm.io/docs/create.html#Default-Values
+	FieldSignable     bool     // detect integer field's unsigned type, adjust generated data type
+	FieldWithIndexTag bool     // generate with gorm index tag
+	FieldWithTypeTag  bool     // generate with gorm column type tag
 
 	Mode GenerateMode // generate mode
 

--- a/generator.go
+++ b/generator.go
@@ -171,6 +171,7 @@ func (g *Generator) genModelConfig(tableName string, modelName string, modelOpts
 
 			FieldSignable:     g.FieldSignable,
 			FieldNullable:     g.FieldNullable,
+			FieldNullableList: g.FieldNullableList,
 			FieldCoverable:    g.FieldCoverable,
 			FieldWithIndexTag: g.FieldWithIndexTag,
 			FieldWithTypeTag:  g.FieldWithTypeTag,

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -21,7 +21,7 @@ func getFields(db *gorm.DB, conf *model.Config, columns []*model.Column) (fields
 		col.SetDataTypeMap(conf.DataTypeMap)
 		col.WithNS(conf.FieldJSONTagNS, conf.FieldNewTagNS)
 
-		m := col.ToField(conf.FieldNullable, conf.FieldCoverable, conf.FieldSignable)
+		m := col.ToField(conf.FieldNullable, conf.FieldCoverable, conf.FieldSignable, conf.FieldNullableList)
 
 		if filterField(m, conf.FilterOpts) == nil {
 			continue

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -35,11 +35,12 @@ type NameStrategy struct {
 type FieldConfig struct {
 	DataTypeMap map[string]func(detailType string) (dataType string)
 
-	FieldNullable     bool // generate pointer when field is nullable
-	FieldCoverable    bool // generate pointer when field has default value
-	FieldSignable     bool // detect integer field's unsigned type, adjust generated data type
-	FieldWithIndexTag bool // generate with gorm index tag
-	FieldWithTypeTag  bool // generate with gorm column type tag
+	FieldNullable     bool     // generate pointer when field is nullable
+	FieldNullableList []string // generate pointer when field is nullable which in FieldNullableList
+	FieldCoverable    bool     // generate pointer when field has default value
+	FieldSignable     bool     // detect integer field's unsigned type, adjust generated data type
+	FieldWithIndexTag bool     // generate with gorm index tag
+	FieldWithTypeTag  bool     // generate with gorm column type tag
 
 	FieldJSONTagNS func(columnName string) string
 	FieldNewTagNS  func(columnName string) string

--- a/internal/model/tbl_column.go
+++ b/internal/model/tbl_column.go
@@ -47,8 +47,17 @@ func (c *Column) WithNS(jsonTagNS, newTagNS func(columnName string) string) {
 	}
 }
 
+func inArr(dataType string, nullableList []string) bool {
+	for _, s := range nullableList {
+		if s == dataType {
+			return true
+		}
+	}
+	return false
+}
+
 // ToField convert to field
-func (c *Column) ToField(nullable, coverable, signable bool) *Field {
+func (c *Column) ToField(nullable, coverable, signable bool, nullableList []string) *Field {
 	fieldType := c.GetDataType()
 	if signable && strings.Contains(c.columnType(), "unsigned") && strings.HasPrefix(fieldType, "int") {
 		fieldType = "u" + fieldType
@@ -58,7 +67,7 @@ func (c *Column) ToField(nullable, coverable, signable bool) *Field {
 		fieldType = "gorm.DeletedAt"
 	case coverable && c.needDefaultTag(c.defaultTagValue()):
 		fieldType = "*" + fieldType
-	case nullable:
+	case nullable || inArr(c.columnType(), nullableList):
 		if n, ok := c.Nullable(); ok && n {
 			fieldType = "*" + fieldType
 		}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

When the field type is in FieldNullableList, nullable fields will be output with pointer

### User Case Description

```  sql
`username` varchar(32),
`last_msg_at` datetime DEFAULT NULL,
`created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
```
if gen.Config.FieldNullableList = []string{"datetime"}
got
```go
Username string 
LastMsgAt *time.Time
CreatedAt time.Time 
```
because `last_msg_at` is nullable and in`FieldNullableList` so got `*time.Time`
`username` is nullable but not in `FieldNullableList`
`created_at` is in not nullable