### PR TITLE
allow to disable secCheck

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -86,4 +86,6 @@ type Dao interface {
 	Scan(dest interface{}) error
 	Pluck(column field.Expr, dest interface{}) error
 	ScanRows(rows *sql.Rows, dest interface{}) error
+
+	WithSecCheckDisabled(disabled bool) Dao
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

> Note: test suite pass but didn't add a new test. Tested the change in real application though.

### What did this pull request do?

Opt-in option to disable secCheck implemented in `DO.Clauses`. The user can disabled the secCheck and enabled it again in the same query chain to take control in complex queries without losing gen benefits.


### User Case Description

We wanted to use OrderBy clause with something like `ORDER BY status DESC NULLS LAST`. This is not possible through the DAO APIS.

Also, secCheck seems to be not fully ready and limit use of clauses. In all ways we can always use `.UnderlyingDB()` to get access to native `*gorm.DB` with no secCheck, but will lose the type-safe APIs and whole purpose of. So it would be nice if we can opt-in to disable this feature to gain full control as-need.

