### PR TITLE
expose AddError via Dao interface

### DIFF
--- a/do.go
+++ b/do.go
@@ -835,6 +835,10 @@ func (d *DO) newResultSlicePointer() interface{} {
 	return reflect.New(reflect.SliceOf(reflect.PtrTo(d.modelType))).Interface()
 }
 
+func (d *DO) AddError(err error) error {
+	return d.withError(err).underlyingDB().Error
+}
+
 func toColExprFullName(stmt *gorm.Statement, columns ...field.Expr) []string {
 	return buildColExpr(stmt, columns, field.WithAll)
 }

--- a/do.go
+++ b/do.go
@@ -836,7 +836,7 @@ func (d *DO) newResultSlicePointer() interface{} {
 }
 
 func (d *DO) AddError(err error) error {
-	return d.withError(err).underlyingDB().Error
+	return d.underlyingDB().AddError(err)
 }
 
 func toColExprFullName(stmt *gorm.Statement, columns ...field.Expr) []string {

--- a/interface.go
+++ b/interface.go
@@ -86,4 +86,6 @@ type Dao interface {
 	Scan(dest interface{}) error
 	Pluck(column field.Expr, dest interface{}) error
 	ScanRows(rows *sql.Rows, dest interface{}) error
+
+	AddError(err error) error
 }


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

> Note: test suite pass but didn't add a new test. Tested the change in real application though.


### What did this pull request do?

Expose `DB.AddError()` to DAO interface. 


### User Case Description

We build most of our queries using reusable `Scopes()` functions. In most cases the query validates few constraints and needs a way to propagate the error back.