### PR TITLE
Fixed generation of DAOs for generic structs

### DIFF
--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -127,6 +127,7 @@ func ConvertStructs(db *gorm.DB, structs ...interface{}) (metas []*QueryStructMe
 
 		structType := reflect.TypeOf(st)
 		name := getStructName(structType.String())
+		typeName := getType(structType.String())
 		newStructName := name
 		if st, ok := st.(interface{ GenInternalDoName() string }); ok {
 			newStructName = st.GenInternalDoName()
@@ -136,7 +137,7 @@ func ConvertStructs(db *gorm.DB, structs ...interface{}) (metas []*QueryStructMe
 			S:               getPureName(name),
 			ModelStructName: name,
 			QueryStructName: uncaptialize(newStructName),
-			StructInfo:      parser.Param{PkgPath: structType.PkgPath(), Type: name, Package: getPackageName(structType.String())},
+			StructInfo:      parser.Param{PkgPath: structType.PkgPath(), Type: typeName, Package: getPackageName(structType.String())},
 			Source:          model.Struct,
 			db:              db,
 		}

--- a/internal/generate/utils.go
+++ b/internal/generate/utils.go
@@ -49,6 +49,15 @@ func getPureName(s string) string {
 // not need capitalize
 func getStructName(t string) string {
 	list := strings.Split(t, ".")
+
+	// when generating DAOs from generic structs, we only want to take what is before the [
+	// Dummy[T any] => Dummy
+	list = strings.Split(list[len(list)-1], "[")
+	return list[0]
+}
+
+func getType(t string) string {
+	list := strings.Split(t, ".")
 	return list[len(list)-1]
 }
 


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Allow gen to generate DAO for generic structs. This throws up an error previously

### User Case Description

```
type User[T any] struct {
	ID        string
	CreatedAt time.Time
	UpdatedAt time.Time
	Params      T `gorm:"type:json;serializer:json"`
}

g := gen.NewGenerator(cfg)
g.ApplyBasic(User[any]{})
g.Execute()
```
