### PR TITLE
feat: add FieldLevelPermission in field options

### DIFF
--- a/field_options.go
+++ b/field_options.go
@@ -147,6 +147,22 @@ var (
 			return m
 		}
 	}
+	// FieldLevelPermission specify GORM tag with level permission
+	// e.g. FieldLevelPermission("->", "created_at", "updated_at") will generate `gorm:"->;column:created_at"` and `gorm:"->;column:updated_at"`
+	FieldLevelPermission = func(level string, columnName ...string) model.ModifyFieldOpt {
+		return func(m *model.Field) *model.Field {
+			for _, name := range columnName {
+				if m.ColumnName == name {
+					if !strings.HasSuffix(level, ";") {
+						level += ";"
+					}
+
+					m.GORMTag = strings.ToLower(level) + m.GORMTag
+				}
+			}
+			return m
+		}
+	}
 	// FieldNewTag add new tag
 	FieldNewTag = func(columnName string, newTag string) model.ModifyFieldOpt {
 		return func(m *model.Field) *model.Field {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Support **Field-Level Permission** in generating the model.

### User Case Description

```sql
create table users
(
    id         int                                      not null comment 'id'
        primary key,
    username   varchar(40)                              not null comment 'username',
    password   varchar(60)                              not null comment 'password',
    created_at datetime(3) default current_timestamp(3) not null comment 'created time',
    updated_at datetime(3) default current_timestamp(3) not null on update current_timestamp(3) comment 'updated time',
);
```

The above MySQL code shows that `created_at` and `updated_at` have default values, and `updated_at` has an `on update` hook.
This means that updates to these two fields do not need to be reflected in the project code, and we do not expect developers to write to these two fields.

If **Field-Level Permission** is not supported, some developers may accidentally fill in these two fields during the development process and the result will not be as expected.