### PR TITLE
 fix setting GOMAXPROCS

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -48,8 +48,6 @@ type RowsAffected int64
 
 var concurrent = runtime.NumCPU()
 
-func init() { runtime.GOMAXPROCS(runtime.NumCPU()) }
-
 // NewGenerator create a new generator
 func NewGenerator(cfg Config) *Generator {
 	if err := cfg.Revise(); err != nil {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

**不需要显示设置GOMAXPROCS，未设置时默认值就是runtime.NumCPU，设置后因为init的执行顺序会影响在容器中设置的环境变量**


GOMAXPROCS 是 Golang 提供的非常重要的一个环境变量设定。通过设定 GOMAXPROCS，可以调整 Runtime Scheduler 中 Processor（简称P）的数量。由于每个系统线程，必须要绑定 P 才能真正地进行执行。所以 P 的数量会很大程度上影响 Golang Runtime 的并发表现。GOMAXPROCS 一般的默认值是 CPU 核数，在容器中一般会通过 cgroup 等技术对 CPU 资源进行隔离。


<!--
provide a general description of the code changes in your pull request
-->
**issues** https://github.com/go-gorm/gen/issues/851

<!-- Your use case -->
