### PR TITLE
feat: add query interface

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -340,6 +340,17 @@ func (g *Generator) generateQueryFile() (err error) {
 		return err
 	}
 
+	if g.judgeMode(WithQueryInterface) {
+		queryInterfaceTmpl := tmpl.QueryInterfaceWithContext
+		if g.judgeMode(WithoutContext) {
+			queryInterfaceTmpl = tmpl.QueryInterfaceWithoutContext
+		}
+		err = render(queryInterfaceTmpl, &buf, g)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = g.output(g.OutFile, buf.Bytes())
 	if err != nil {
 		return err

--- a/internal/template/query.go
+++ b/internal/template/query.go
@@ -111,6 +111,42 @@ func (q *QueryTx) RollbackTo(name string) error {
 
 `
 
+// QueryInterfaceWithContext interface method template with context
+const QueryInterfaceWithContext = `
+var _ IQuery = (*Query)(nil)
+
+type IQuery interface{
+	{{range $name,$d :=.Data -}}
+	{{$d.ModelStructName}}Do(ctx context.Context) I{{$d.ModelStructName}}Do
+	{{end -}}
+}
+
+{{range $name,$d :=.Data -}}
+func (q *Query) {{$d.ModelStructName}}Do(ctx context.Context) I{{$d.ModelStructName}}Do {
+	return q.{{$d.ModelStructName}}.WithContext(ctx)
+}
+
+{{end -}}
+`
+
+// QueryInterfaceWithoutContext interface method template without context
+const QueryInterfaceWithoutContext = `
+var _ IQuery = (*Query)(nil)
+
+type IQuery interface{
+	{{range $name,$d :=.Data -}}
+	{{$d.ModelStructName}}Do() I{{$d.ModelStructName}}Do
+	{{end -}}
+}
+
+{{range $name,$d :=.Data -}}
+func (q *Query) {{$d.ModelStructName}}Do() I{{$d.ModelStructName}}Do {
+	return &q.{{$d.ModelStructName}}.{{$d.QueryStructName}}Do
+}
+
+{{end -}}
+`
+
 // QueryMethodTest query method test template
 const QueryMethodTest = `
 

--- a/tests/.expect/dal_3/query/gen.go
+++ b/tests/.expect/dal_3/query/gen.go
@@ -133,3 +133,33 @@ func (q *QueryTx) SavePoint(name string) error {
 func (q *QueryTx) RollbackTo(name string) error {
 	return q.db.RollbackTo(name).Error
 }
+
+var _ IQuery = (*Query)(nil)
+
+type IQuery interface {
+	BankDo(ctx context.Context) IBankDo
+	CreditCardDo(ctx context.Context) ICreditCardDo
+	CustomerDo(ctx context.Context) ICustomerDo
+	PersonDo(ctx context.Context) IPersonDo
+	UserDo(ctx context.Context) IUserDo
+}
+
+func (q *Query) BankDo(ctx context.Context) IBankDo {
+	return q.Bank.WithContext(ctx)
+}
+
+func (q *Query) CreditCardDo(ctx context.Context) ICreditCardDo {
+	return q.CreditCard.WithContext(ctx)
+}
+
+func (q *Query) CustomerDo(ctx context.Context) ICustomerDo {
+	return q.Customer.WithContext(ctx)
+}
+
+func (q *Query) PersonDo(ctx context.Context) IPersonDo {
+	return q.Person.WithContext(ctx)
+}
+
+func (q *Query) UserDo(ctx context.Context) IUserDo {
+	return q.User.WithContext(ctx)
+}

--- a/tests/.expect/dal_4/query/gen.go
+++ b/tests/.expect/dal_4/query/gen.go
@@ -133,3 +133,33 @@ func (q *QueryTx) SavePoint(name string) error {
 func (q *QueryTx) RollbackTo(name string) error {
 	return q.db.RollbackTo(name).Error
 }
+
+var _ IQuery = (*Query)(nil)
+
+type IQuery interface {
+	BankDo(ctx context.Context) IBankDo
+	CreditCardDo(ctx context.Context) ICreditCardDo
+	CustomerDo(ctx context.Context) ICustomerDo
+	PersonDo(ctx context.Context) IPersonDo
+	UserDo(ctx context.Context) IUserDo
+}
+
+func (q *Query) BankDo(ctx context.Context) IBankDo {
+	return q.Bank.WithContext(ctx)
+}
+
+func (q *Query) CreditCardDo(ctx context.Context) ICreditCardDo {
+	return q.CreditCard.WithContext(ctx)
+}
+
+func (q *Query) CustomerDo(ctx context.Context) ICustomerDo {
+	return q.Customer.WithContext(ctx)
+}
+
+func (q *Query) PersonDo(ctx context.Context) IPersonDo {
+	return q.Person.WithContext(ctx)
+}
+
+func (q *Query) UserDo(ctx context.Context) IUserDo {
+	return q.User.WithContext(ctx)
+}

--- a/tests/.expect/dal_5/query/gen.go
+++ b/tests/.expect/dal_5/query/gen.go
@@ -101,3 +101,13 @@ func (q *QueryTx) SavePoint(name string) error {
 func (q *QueryTx) RollbackTo(name string) error {
 	return q.db.RollbackTo(name).Error
 }
+
+var _ IQuery = (*Query)(nil)
+
+type IQuery interface {
+	UserDo(ctx context.Context) IUserDo
+}
+
+func (q *Query) UserDo(ctx context.Context) IUserDo {
+	return q.User.WithContext(ctx)
+}

--- a/tests/.expect/dal_6/query/gen.go
+++ b/tests/.expect/dal_6/query/gen.go
@@ -101,3 +101,13 @@ func (q *QueryTx) SavePoint(name string) error {
 func (q *QueryTx) RollbackTo(name string) error {
 	return q.db.RollbackTo(name).Error
 }
+
+var _ IQuery = (*Query)(nil)
+
+type IQuery interface {
+	UserDo(ctx context.Context) IUserDo
+}
+
+func (q *Query) UserDo(ctx context.Context) IUserDo {
+	return q.User.WithContext(ctx)
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?
Now `gen.WithQueryInterface` only generates interface for DO object.  Considering that DO object uses `context` to initialilze, most services would import `Query` instead of some DO object. In that case, it would be difficult to mock `Query` because `Query` is just a struct. It would be easier to mock if we have a interface for Query.
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
