### PR TITLE
FIX: input tablename with space

### DIFF
--- a/tools/gentool/gen.yml
+++ b/tools/gentool/gen.yml
@@ -10,6 +10,8 @@ database:
   #   - users
   #   - goods
   tables  :
+  # only generate models (without query file)
+  onlyModel : false
   # specify a directory for output
   outPath :  "./dao/query"
   # query code file name, default: gen.go

--- a/tools/gentool/gentool.go
+++ b/tools/gentool/gentool.go
@@ -141,7 +141,13 @@ func argParse() *CmdParams {
 		cmdParse.DB = *db
 	}
 	if *tableList != "" {
-		cmdParse.Tables = strings.Split(*tableList, ",")
+		for _, tableName := range strings.Split(*tableList, ",") {
+			_tableName := strings.TrimSpace(tableName) // trim leading and trailing space in tableName
+			if _tableName == "" { // skip empty tableName
+				continue
+			}
+			cmdParse.Tables = append(cmdParse.Tables, _tableName)
+		}
 	}
 	if *onlyModel {
 		cmdParse.OnlyModel = true


### PR DESCRIPTION
### What did this pull request do?
1. append the `onlyModel` in `tools/gentool/gen.yml`
2. fix a table name input bug
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
set `tableList` content in cmdline, looks like this: `"users, orgs "`
then you get the `users.gen.go`, ` orgs .gen.go`(filename with a space in the first and last) after generate execution.
<!-- Your use case -->
