### PR TITLE
Fix copy paste mistake in method comment

### DIFF
--- a/internal/generate/interface.go
+++ b/internal/generate/interface.go
@@ -156,7 +156,7 @@ func (m *InterfaceMethod) DocComment() string {
 	return strings.Replace(strings.Replace(strings.TrimSpace(m.Doc), "\n", "\n// ", -1), "//  ", "// ", -1)
 }
 
-// checkParams check all parameters
+// checkMethod check interface methods
 func (m *InterfaceMethod) checkMethod(methods []*InterfaceMethod, s *QueryStructMeta) (err error) {
 	if model.GormKeywords.FullMatch(m.MethodName) {
 		return fmt.Errorf("can not use keyword as method name:%s", m.MethodName)


### PR DESCRIPTION
This commit fixes a place where the method comment didn't match the definition due to a copy paste from its neighbor.

Background: I'm doing a research study on function comments that may be improvable. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
