### PR TITLE
fix: default value with type casting

### DIFF
--- a/internal/model/tbl_column.go
+++ b/internal/model/tbl_column.go
@@ -150,6 +150,12 @@ func (c *Column) defaultTagValue() string {
 	if value != "" && strings.TrimSpace(value) == "" {
 		return "'" + value + "'"
 	}
+	const castSeparator = "::"
+	values := strings.Split(value, castSeparator)
+	valuesSize := len(values)
+	if valuesSize > 1 && values[valuesSize-1] == c.columnType() {
+		return strings.Join(values[:valuesSize-1], "")
+	}
 	return value
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

In the previous implementation, when the value contained a "::" or type-casting indicator, it wasn't processed correctly.
Value casting in default values is allowed in PostgreSQL. 

### User Case Description

<!-- Your use case -->
