### PR TITLE
fix: gentool config file ignored bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/gen
 go 1.18
 
 require (
+	github.com/creasty/defaults v1.7.0
 	golang.org/x/tools v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/creasty/defaults v1.7.0 h1:eNdqZvc5B509z18lD8yc212CAqJNvfT1Jq6L8WowdBA=
+github.com/creasty/defaults v1.7.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tools/gentool/gentool.go
+++ b/tools/gentool/gentool.go
@@ -15,6 +15,8 @@ import (
 	"gorm.io/driver/sqlserver"
 	"gorm.io/gen"
 	"gorm.io/gorm"
+
+	"github.com/creasty/defaults"
 )
 
 // DBType database type
@@ -31,18 +33,29 @@ const (
 
 // CmdParams is command line parameters
 type CmdParams struct {
-	DSN               string   `yaml:"dsn"`               // consult[https://gorm.io/docs/connecting_to_the_database.html]"
-	DB                string   `yaml:"db"`                // input mysql or postgres or sqlite or sqlserver. consult[https://gorm.io/docs/connecting_to_the_database.html]
-	Tables            []string `yaml:"tables"`            // enter the required data table or leave it blank
-	OnlyModel         bool     `yaml:"onlyModel"`         // only generate model
-	OutPath           string   `yaml:"outPath"`           // specify a directory for output
-	OutFile           string   `yaml:"outFile"`           // query code file name, default: gen.go
-	WithUnitTest      bool     `yaml:"withUnitTest"`      // generate unit test for query code
-	ModelPkgName      string   `yaml:"modelPkgName"`      // generated model code's package name
-	FieldNullable     bool     `yaml:"fieldNullable"`     // generate with pointer when field is nullable
-	FieldWithIndexTag bool     `yaml:"fieldWithIndexTag"` // generate field with gorm index tag
-	FieldWithTypeTag  bool     `yaml:"fieldWithTypeTag"`  // generate field with gorm column type tag
-	FieldSignable     bool     `yaml:"fieldSignable"`     // detect integer field's unsigned type, adjust generated data type
+	DSN               string   `yaml:"dsn"`                           // consult[https://gorm.io/docs/connecting_to_the_database.html]"
+	DB                string   `yaml:"db" default:"mysql"`            // input mysql or postgres or sqlite or sqlserver. consult[https://gorm.io/docs/connecting_to_the_database.html]
+	Tables            []string `yaml:"tables"`                        // enter the required data table or leave it blank
+	OnlyModel         bool     `yaml:"onlyModel"`                     // only generate model
+	OutPath           string   `yaml:"outPath" default:"./dao/query"` // specify a directory for output
+	OutFile           string   `yaml:"outFile"`                       // query code file name, default: gen.go
+	WithUnitTest      bool     `yaml:"withUnitTest"`                  // generate unit test for query code
+	ModelPkgName      string   `yaml:"modelPkgName"`                  // generated model code's package name
+	FieldNullable     bool     `yaml:"fieldNullable"`                 // generate with pointer when field is nullable
+	FieldWithIndexTag bool     `yaml:"fieldWithIndexTag"`             // generate field with gorm index tag
+	FieldWithTypeTag  bool     `yaml:"fieldWithTypeTag"`              // generate field with gorm column type tag
+	FieldSignable     bool     `yaml:"fieldSignable"`                 // detect integer field's unsigned type, adjust generated data type
+}
+
+func (c *CmdParams) UnmarshalYAML(unmarshal func(any) error) error {
+	defaults.Set(c)
+
+	type plain CmdParams
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // YamlConfig is yaml config struct
@@ -113,10 +126,10 @@ func argParse() *CmdParams {
 	// choose is file or flag
 	genPath := flag.String("c", "", "is path for gen.yml")
 	dsn := flag.String("dsn", "", "consult[https://gorm.io/docs/connecting_to_the_database.html]")
-	db := flag.String("db", "mysql", "input mysql|postgres|sqlite|sqlserver|clickhouse. consult[https://gorm.io/docs/connecting_to_the_database.html]")
+	db := flag.String("db", "", "input mysql|postgres|sqlite|sqlserver|clickhouse. consult[https://gorm.io/docs/connecting_to_the_database.html]")
 	tableList := flag.String("tables", "", "enter the required data table or leave it blank")
 	onlyModel := flag.Bool("onlyModel", false, "only generate models (without query file)")
-	outPath := flag.String("outPath", "./dao/query", "specify a directory for output")
+	outPath := flag.String("outPath", "", "specify a directory for output")
 	outFile := flag.String("outFile", "", "query code file name, default: gen.go")
 	withUnitTest := flag.Bool("withUnitTest", false, "generate unit test for query code")
 	modelPkgName := flag.String("modelPkgName", "", "generated model code's package name")


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

#### Before the fix

Part of the content of the gentool configuration file is ignored. This is because the default values set in the command line arguments take priority over them.


##### Example
1. 
```shell
$ cd './tools/gentool'
```

2. Update `gen.yml`. Set the value of `db` to `postgres`.

3.
```shell
$ go run . -c "./gen.yml"
```

If you could output the logs you would see that, the value of `db` is executed as `mysql`. This is because the default value of the command-line arguments is given priority.

#### After the fix

The content of the gentool configuration file will be reflected. However, if command-line arguments are specified, they will be given priority. This behavior is the same as before the fix.


<!-- ### User Case Description -->

<!-- Your use case -->
