### PR TITLE
add fieldCoverable param to gentool

### DIFF
--- a/tools/gentool/README.ZH_CN.md
+++ b/tools/gentool/README.ZH_CN.md
@@ -23,6 +23,8 @@
         consult[https://gorm.io/docs/connecting_to_the_database.html]
   -fieldNullable
         generate with pointer when field is nullable
+  -fieldCoverable
+        generate with pointer when field has default value
   -fieldWithIndexTag
         generate field with gorm index tag
   -fieldWithTypeTag
@@ -67,6 +69,10 @@ default ""
 #### fieldNullable
 
 字段可为空时使用指针生成
+
+#### fieldCoverable
+
+字段有默认值时使用指针生成
 
 #### fieldWithIndexTag
 

--- a/tools/gentool/README.md
+++ b/tools/gentool/README.md
@@ -21,6 +21,8 @@ Install GEN as a binary tool
         consult[https://gorm.io/docs/connecting_to_the_database.html]
   -fieldNullable
         generate with pointer when field is nullable
+  -fieldCoverable
+        generate with pointer when field has default value
   -fieldWithIndexTag
         generate field with gorm index tag
   -fieldWithTypeTag
@@ -65,6 +67,10 @@ You can use all gorm's dsn.
 #### fieldNullable
 
 generate with pointer when field is nullable
+
+#### fieldCoverable
+
+generate with pointer when field has default value
 
 #### fieldWithIndexTag
 

--- a/tools/gentool/gen.yml
+++ b/tools/gentool/gen.yml
@@ -22,6 +22,8 @@ database:
   modelPkgName  : ""
   # generate with pointer when field is nullable
   fieldNullable : false
+  # generate with pointer when field has default value
+  fieldCoverable : false
   # generate field with gorm index tag
   fieldWithIndexTag : false
   # generate field with gorm column type tag

--- a/tools/gentool/gentool.go
+++ b/tools/gentool/gentool.go
@@ -211,8 +211,6 @@ func main() {
 		log.Fatalln("parse config fail")
 	}
 
-	fmt.Printf("config: %+v\n", *config)
-
 	db, err := connectDB(DBType(config.DB), config.DSN)
 	if err != nil {
 		log.Fatalln("connect db server fail:", err)

--- a/tools/gentool/gentool.go
+++ b/tools/gentool/gentool.go
@@ -43,6 +43,7 @@ type CmdParams struct {
 	WithUnitTest      bool     `yaml:"withUnitTest"`      // generate unit test for query code
 	ModelPkgName      string   `yaml:"modelPkgName"`      // generated model code's package name
 	FieldNullable     bool     `yaml:"fieldNullable"`     // generate with pointer when field is nullable
+	FieldCoverable    bool     `yaml:"fieldCoverable"`    // generate with pointer when field has default value
 	FieldWithIndexTag bool     `yaml:"fieldWithIndexTag"` // generate field with gorm index tag
 	FieldWithTypeTag  bool     `yaml:"fieldWithTypeTag"`  // generate field with gorm column type tag
 	FieldSignable     bool     `yaml:"fieldSignable"`     // detect integer field's unsigned type, adjust generated data type
@@ -149,6 +150,7 @@ func argParse() *CmdParams {
 	withUnitTest := flag.Bool("withUnitTest", false, "generate unit test for query code")
 	modelPkgName := flag.String("modelPkgName", "", "generated model code's package name")
 	fieldNullable := flag.Bool("fieldNullable", false, "generate with pointer when field is nullable")
+	fieldCoverable := flag.Bool("fieldCoverable", false, "generate with pointer when field has default value")
 	fieldWithIndexTag := flag.Bool("fieldWithIndexTag", false, "generate field with gorm index tag")
 	fieldWithTypeTag := flag.Bool("fieldWithTypeTag", false, "generate field with gorm column type tag")
 	fieldSignable := flag.Bool("fieldSignable", false, "detect integer field's unsigned type, adjust generated data type")
@@ -187,6 +189,9 @@ func argParse() *CmdParams {
 	if *fieldNullable {
 		cmdParse.FieldNullable = *fieldNullable
 	}
+	if *fieldCoverable {
+		cmdParse.FieldCoverable = *fieldCoverable
+	}
 	if *fieldWithIndexTag {
 		cmdParse.FieldWithIndexTag = *fieldWithIndexTag
 	}
@@ -205,6 +210,9 @@ func main() {
 	if config == nil {
 		log.Fatalln("parse config fail")
 	}
+
+	fmt.Printf("config: %+v\n", *config)
+
 	db, err := connectDB(DBType(config.DB), config.DSN)
 	if err != nil {
 		log.Fatalln("connect db server fail:", err)
@@ -216,6 +224,7 @@ func main() {
 		ModelPkgPath:      config.ModelPkgName,
 		WithUnitTest:      config.WithUnitTest,
 		FieldNullable:     config.FieldNullable,
+		FieldCoverable:    config.FieldCoverable,
 		FieldWithIndexTag: config.FieldWithIndexTag,
 		FieldWithTypeTag:  config.FieldWithTypeTag,
 		FieldSignable:     config.FieldSignable,


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

 `FieldCoverable` parameter exists, but it is missing in gentool. I added it.
refer:  https://gorm.io/gen/database_to_structs.html#Global-Generating-Options

<!-- ### User Case Description -->

<!-- Your use case -->
