### PR TITLE
feat: add lower and upper

### DIFF
--- a/field/string.go
+++ b/field/string.go
@@ -123,6 +123,16 @@ func (field String) Concat(before, after string) String {
 	}
 }
 
+// Lower converts a string to lower-case.
+func (field String) Lower() String {
+	return String{expr{e: clause.Expr{SQL: "LOWER(?)", Vars: []interface{}{field.RawExpr()}}}}
+}
+
+// Upper converts a string to upper-case.
+func (field String) Upper() String {
+	return String{expr{e: clause.Expr{SQL: "UPPER(?)", Vars: []interface{}{field.RawExpr()}}}}
+}
+
 // Filed ...
 func (field String) Filed(values ...string) String {
 	return String{field.field(values)}
@@ -241,6 +251,16 @@ func (field Bytes) FindInSet(targetList string) Expr {
 // FindInSetWith FIND_IN_SET(input_string, field_name)
 func (field Bytes) FindInSetWith(target string) Expr {
 	return expr{e: clause.Expr{SQL: "FIND_IN_SET(?,?)", Vars: []interface{}{target, field.RawExpr()}}}
+}
+
+// Lower converts a string to lower-case.
+func (field Bytes) Lower() String {
+	return String{expr{e: clause.Expr{SQL: "LOWER(?)", Vars: []interface{}{field.RawExpr()}}}}
+}
+
+// Upper converts a string to upper-case.
+func (field Bytes) Upper() String {
+	return String{expr{e: clause.Expr{SQL: "UPPER(?)", Vars: []interface{}{field.RawExpr()}}}}
 }
 
 // Filed ...


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
给 field.String 添加了 `Lower` 方法 和 `Upper` 方法，个人认为他们虽然是两个方法，但功能类似，是作用相反的一对，所以放到一个 pr 中了

添加这两个方法的原因是目前 gen 好像无法方便的使用除生成外的其他 sql 方法

以下是我在Issues搜索时看到的，作为参考
- https://github.com/go-gorm/gen/issues/460
- https://github.com/go-gorm/gen/issues/545

 二是 Lower 和 Upper 在 sql-92 compatible 中有定义，有广泛的兼容性

### User Case Description

<!-- Your use case -->

在使用 like 搜索的场景时，经常会有“不区分大小写”的场景，除了使用各sql方言的特殊方法，比如 postgres 的 'ilike'，另一种简单粗暴的方法就是用 Lower 将关键词和内容都转为小写，以下是该方法使用例子

```go
keyword := fmt.Sprintf("%s%%", strings.ToLower(opt.Keyword))
count, err := user.WithContext(ctx).
    Where(user.Nickname.Lower().Like(keyword)).
    Or(user.Username.Lower().Like(keyword)).
    FindByPage(opt.Offset, opt.Limit)
```