### PR TITLE
fix: fix sql render bug after use ReplaceDB & UseDB lost db context

### DIFF
--- a/do.go
+++ b/do.go
@@ -50,7 +50,7 @@ var (
 
 // UseDB specify a db connection(*gorm.DB)
 func (d *DO) UseDB(db *gorm.DB, opts ...DOOption) {
-	db = db.Session(&gorm.Session{Context: context.Background()})
+	db = db.Session(&gorm.Session{Context: db.Statement.Context})
 	d.db = db
 	config := &DOConfig{}
 	for _, opt := range opts {
@@ -65,7 +65,8 @@ func (d *DO) UseDB(db *gorm.DB, opts ...DOOption) {
 
 // ReplaceDB replace db connection
 func (d *DO) ReplaceDB(db *gorm.DB) {
-	d.db = db.Session(&gorm.Session{})
+	d.db = db.Session(&gorm.Session{Context: db.Statement.Context})
+	d.UseModel(reflect.New(d.modelType).Interface())
 }
 
 // ReplaceConnPool replace db connection pool


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
fix bugs
1. `DO.UseDB` will lost db.Statement.Context
2. `DO.ReplaceDB` will lost table name
3. `DO.ReplaceDB` will not clone db.Statement, so after `Query.ReplaceDB`, all Dao use same Statement

### User Case Description

<!-- Your use case -->
before fixed, `u.Not(gen.Exists(student.Where(u.ID.EqCol(student.ID)))).Count()` will return error
