### PR TITLE
Add option to use custom nullable column type formater

### DIFF
--- a/config.go
+++ b/config.go
@@ -54,8 +54,9 @@ type Config struct {
 	modelNameNS func(tableName string) (modelName string)
 	fileNameNS  func(tableName string) (fileName string)
 
-	dataTypeMap    map[string]func(columnType gorm.ColumnType) (dataType string)
-	fieldJSONTagNS func(columnName string) (tagContent string)
+	dataTypeMap     map[string]func(columnType gorm.ColumnType) (dataType string)
+	fieldJSONTagNS  func(columnName string) (tagContent string)
+	fieldNullableNS func(columnType string) (nullableColumnType string)
 
 	modelOpts []ModelOpt
 }
@@ -101,6 +102,11 @@ func (cfg *Config) WithDataTypeMap(newMap map[string]func(columnType gorm.Column
 // WithJSONTagNameStrategy specify json tag naming strategy
 func (cfg *Config) WithJSONTagNameStrategy(ns func(columnName string) (tagContent string)) {
 	cfg.fieldJSONTagNS = ns
+}
+
+// WithNullableNameStrategy specify nullable type name strategy
+func (cfg *Config) WithNullableNameStrategy(ns func(columnType string) (nullableColumnType string)) {
+	cfg.fieldNullableNS = ns
 }
 
 // WithImportPkgPath specify import package path

--- a/generator.go
+++ b/generator.go
@@ -183,7 +183,8 @@ func (g *Generator) genModelConfig(tableName string, modelName string, modelOpts
 			FieldWithIndexTag: g.FieldWithIndexTag,
 			FieldWithTypeTag:  g.FieldWithTypeTag,
 
-			FieldJSONTagNS: g.fieldJSONTagNS,
+			FieldNullableNS: g.fieldNullableNS,
+			FieldJSONTagNS:  g.fieldJSONTagNS,
 		},
 	}
 }

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -20,6 +20,7 @@ func getFields(db *gorm.DB, conf *model.Config, columns []*model.Column) (fields
 	for _, col := range columns {
 		col.SetDataTypeMap(conf.DataTypeMap)
 		col.WithNS(conf.FieldJSONTagNS)
+		col.WithNullableFieldTypeNS(conf.FieldNullableNS)
 
 		m := col.ToField(conf.FieldNullable, conf.FieldCoverable, conf.FieldSignable)
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -35,17 +35,18 @@ type NameStrategy struct {
 type FieldConfig struct {
 	DataTypeMap map[string]func(columnType gorm.ColumnType) (dataType string)
 
-	FieldNullable     bool // generate pointer when field is nullable
+	FieldNullable     bool // Use FieldNullableFormater when field is nullable
 	FieldCoverable    bool // generate pointer when field has default value
 	FieldSignable     bool // detect integer field's unsigned type, adjust generated data type
 	FieldWithIndexTag bool // generate with gorm index tag
 	FieldWithTypeTag  bool // generate with gorm column type tag
 
 	FieldJSONTagNS func(columnName string) string
-
-	ModifyOpts []FieldOption
-	FilterOpts []FieldOption
-	CreateOpts []FieldOption
+	// Formater used when field is nullable and FieldNullable is true. Default : generate pointer
+	FieldNullableNS func(columnType string) string
+	ModifyOpts      []FieldOption
+	FilterOpts      []FieldOption
+	CreateOpts      []FieldOption
 }
 
 // MethodConfig method configuration


### PR DESCRIPTION
Add the option WithNullableNameStrategy in order to use a custom nullable column type formater.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x ] Do only one thing
- [x ] Non breaking API changes
- [x ] Tested

### What did this pull request do?

Add the option WithNullableNameStrategy in order to use a custom nullable column type formater.

### User Case Description

```
package main

import (
	"fmt"

	"gorm.io/driver/postgres"
	"gorm.io/gen"
	"gorm.io/gorm"
)

func jsonMapFunc(columnType gorm.ColumnType) (dataType string) {
	return "*nullable.Of[nullable.JSON]"
}

var dataMap = map[string]func(gorm.ColumnType) (dataType string){
	"json":  jsonMapFunc,
	"jsonb": jsonMapFunc,
}

func main() {
	config := gen.Config{
		OutPath:       "./query",
		Mode:          gen.WithDefaultQuery | gen.WithQueryInterface,
		ModelPkgPath:  "model",
		FieldNullable: true,
	}

	config.WithNullableNameStrategy(func(fType string) string {
		return fmt.Sprintf("*nullable.Of[%s]", fType)
	})
	config.WithImportPkgPath("github.com/ovya/nullable")

	g := gen.NewGenerator(config)

	gormdb, _ := gorm.Open(postgres.Open("host=127.0.0.1 port=5432 dbname=db user=user password=pass sslmode=disable connect_timeout=30"))
	g.UseDB(gormdb)
	g.WithDataTypeMap(dataMap)

	g.ApplyBasic(
		g.GenerateAllTable()...,
	)

	g.Execute()
}
```