### PR TITLE
When a custom model is used in AppleInterface

### DIFF
--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -50,7 +50,7 @@ func (b *QueryStructMeta) parseStruct(st interface{}) error {
 	if err != nil {
 		return err
 	}
-	b.TableName = stmt.Table
+	b.TableName = b.db.NamingStrategy.TableName(stmt.Table)
 	b.FileName = strings.ToLower(stmt.Table)
 
 	var fp FieldParser = dummyFieldParser{}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

Adds a prefix to tables when using a custom model in ApplyInterface

### User Case Description
```
type Querier interface {
	// SELECT * FROM @@table WHERE uuid = @uuid
	FilterWithUUID(uuid string) ([]gen.T, error)
}

//....

g.ApplyInterface(func(Querier){}, custom.User{})
```
RESULT:
Method FilterWithUUID in users.gen.go **before**:
```
func (u userDo) u(uuid string) (result []types.User, err error) {
	var params []interface{}

	var generateSQL strings.Builder
	params = append(params, uuid)
	generateSQL.WriteString("SELECT * FROM users WHERE uuid = ? ")

	var executeSQL *gorm.DB
	executeSQL = u.UnderlyingDB().Raw(generateSQL.String(), params...).Find(&result) // ignore_security_alert
	err = executeSQL.Error

	return
}
```
and **after** fix:
```
func (u userDo) u(uuid string) (result []types.User, err error) {
	var params []interface{}

	var generateSQL strings.Builder
	params = append(params, uuid)
	generateSQL.WriteString("SELECT * FROM table_prefix.users WHERE uuid = ? ")

	var executeSQL *gorm.DB
	executeSQL = u.UnderlyingDB().Raw(generateSQL.String(), params...).Find(&result) // ignore_security_alert
	err = executeSQL.Error

	return
}
```
