### PR TITLE
feat: extended helper interface to support custom object method and i…

### DIFF
--- a/examples/cmd/from_object/prepare.go
+++ b/examples/cmd/from_object/prepare.go
@@ -32,6 +32,11 @@ func (d *Demo) ImportPkgPaths() []string { return nil }
 // Fields return fields
 func (d *Demo) Fields() []helper.Field { return d.fields }
 
+// Methods return method array
+func (d *Demo) Methods() []helper.Method {
+	return nil
+}
+
 // DemoField demo field
 type DemoField struct {
 	name    string

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/tools v0.15.0 // indirect
+	golang.org/x/tools v0.17.0 // indirect
 	gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c // indirect
 	gorm.io/hints v1.1.0 // indirect
 	gorm.io/plugin/dbresolver v1.5.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -35,6 +35,7 @@ golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
 golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/datatypes v1.1.1-0.20230130040222-c43177d3cf8c h1:jWdr7cHgl8c/ua5vYbR2WhSp+NQmzhsj0xoY3foTzW8=

--- a/generator.go
+++ b/generator.go
@@ -462,7 +462,7 @@ func (g *Generator) generateQueryUnitTestFile(data *genInfo) (err error) {
 	}
 	err = render(tmpl.Header, &buf, map[string]interface{}{
 		"Package":        g.queryPkgName,
-		"ImportPkgPaths": unitTestImportList.Add(structPkgPath).Add(data.ImportPkgPaths...).Paths(),
+		"ImportPkgPaths": unitTestQueryImportList.Add(structPkgPath).Add(data.ImportPkgPaths...).Paths(),
 	})
 	if err != nil {
 		return err

--- a/helper/interface.go
+++ b/helper/interface.go
@@ -1,0 +1,11 @@
+package helper
+
+// Interface Custom query interface define.
+type Interface interface {
+	// Name return interface name
+	Name() string
+	// Methods return interface methods
+	Methods() []Method
+	// Package return interface packet
+	Package() string
+}

--- a/helper/object.go
+++ b/helper/object.go
@@ -67,6 +67,7 @@ func CheckObject(obj Object) error {
 	return nil
 }
 
+// Method an object method interface
 type Method interface {
 	// Name return func name
 	Name() string
@@ -82,6 +83,7 @@ type Method interface {
 	Body() string
 }
 
+// Param an method param interface
 type Param interface {
 	// PackagePath return package path
 	PackagePath() string

--- a/helper/object.go
+++ b/helper/object.go
@@ -17,9 +17,10 @@ type Object interface {
 	FileName() string
 	// ImportPkgPaths return need import package path
 	ImportPkgPaths() []string
-
 	// Fields return field array
 	Fields() []Field
+	// Methods return method array
+	Methods() []Method
 }
 
 // Field a field interface
@@ -56,5 +57,42 @@ func CheckObject(obj Object) error {
 			return fmt.Errorf("Object %s's Field.Type() cannot be empty", obj.StructName())
 		}
 	}
+
+	for _, method := range obj.Methods() {
+		if method.Name() == "" {
+			return fmt.Errorf("object %s's Method.Name() cannot be empty", obj.StructName())
+		}
+	}
+
 	return nil
+}
+
+type Method interface {
+	// Name return func name
+	Name() string
+	// Receiver return func receiver
+	Receiver() Param
+	// Comment return func comment
+	Comment() string
+	// Params return func input args
+	Params() []Param
+	// Result return func return args
+	Result() []Param
+	// Body return func body
+	Body() string
+}
+
+type Param interface {
+	// PackagePath return package path
+	PackagePath() string
+	// PackageName return package name
+	PackageName() string
+	// TypeName return param type name
+	TypeName() string
+	// IsPointer return if param type is pointer
+	IsPointer() bool
+	// IsArray return if param type is array
+	IsArray() bool
+	// Name return param name
+	Name() string
 }

--- a/import.go
+++ b/import.go
@@ -27,6 +27,16 @@ var (
 		"gorm.io/driver/sqlite",
 		"gorm.io/gorm",
 	)
+	unitTestQueryImportList = new(importPkgS).Add(
+		"context",
+		"fmt",
+		"strconv",
+		"testing",
+		"",
+		"gorm.io/gen",
+		"gorm.io/gen/field",
+		"gorm.io/gorm/clause",
+	)
 )
 
 type importPkgS struct {

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -73,6 +73,7 @@ func getMethodParamFromParamObjs(objs []helper.Param) []parser.Param {
 	return list
 }
 
+// GetMethodFromObj convert helper.Method to parser.Method.
 func GetMethodFromObj(md helper.Method) *parser.Method {
 	return &parser.Method{
 		Receiver:   getMethodParamFromParamObj(md.Receiver()),
@@ -83,6 +84,8 @@ func GetMethodFromObj(md helper.Method) *parser.Method {
 		Body:       md.Body(),
 	}
 }
+
+// GetMethodSliceFromObj convert helper.Method slice to parser.Method slice.
 func GetMethodSliceFromObj(mds []helper.Method) []*parser.Method {
 	res := make([]*parser.Method, 0, len(mds))
 	for _, md := range mds {

--- a/internal/parser/export.go
+++ b/internal/parser/export.go
@@ -40,7 +40,7 @@ func GetInterfacePath(v interface{}) (paths []*InterfacePath, err error) {
 		var p *build.Package
 
 		if strings.Split(arg.String(), ".")[0] == "main" {
-			_, file, _, _ := runtime.Caller(3)
+			_, file, _, _ := runtime.Caller(2)
 			p, err = ctx.ImportDir(filepath.Dir(file), build.ImportComment)
 		} else {
 			p, err = ctx.Import(arg.PkgPath(), "", build.ImportComment)

--- a/tests/.expect/dal_2/query/banks.gen_test.go
+++ b/tests/.expect/dal_2/query/banks.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_2/query/credit_cards.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_2/query/credit_cards.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_2/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_2/query/credit_cards.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/customers.gen_test.go
+++ b/tests/.expect/dal_2/query/customers.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/customers.gen_test.go
+++ b/tests/.expect/dal_2/query/customers.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_2/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/customers.gen_test.go
+++ b/tests/.expect/dal_2/query/customers.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/people.gen_test.go
+++ b/tests/.expect/dal_2/query/people.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/people.gen_test.go
+++ b/tests/.expect/dal_2/query/people.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_2/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/people.gen_test.go
+++ b/tests/.expect/dal_2/query/people.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/users.gen_test.go
+++ b/tests/.expect/dal_2/query/users.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/users.gen_test.go
+++ b/tests/.expect/dal_2/query/users.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_2/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_2/query/users.gen_test.go
+++ b/tests/.expect/dal_2/query/users.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_2/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_2/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/banks.gen_test.go
+++ b/tests/.expect/dal_3/query/banks.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_3/query/credit_cards.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_3/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_3/query/credit_cards.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_3/query/credit_cards.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/customers.gen_test.go
+++ b/tests/.expect/dal_3/query/customers.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_3/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/customers.gen_test.go
+++ b/tests/.expect/dal_3/query/customers.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/customers.gen_test.go
+++ b/tests/.expect/dal_3/query/customers.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/people.gen_test.go
+++ b/tests/.expect/dal_3/query/people.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_3/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/people.gen_test.go
+++ b/tests/.expect/dal_3/query/people.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/people.gen_test.go
+++ b/tests/.expect/dal_3/query/people.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/users.gen_test.go
+++ b/tests/.expect/dal_3/query/users.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_3/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/users.gen_test.go
+++ b/tests/.expect/dal_3/query/users.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_3/query/users.gen_test.go
+++ b/tests/.expect/dal_3/query/users.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_3/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_3/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/banks.gen_test.go
+++ b/tests/.expect/dal_4/query/banks.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_4/query/credit_cards.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_4/query/credit_cards.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/credit_cards.gen_test.go
+++ b/tests/.expect/dal_4/query/credit_cards.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_4/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/customers.gen_test.go
+++ b/tests/.expect/dal_4/query/customers.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/customers.gen_test.go
+++ b/tests/.expect/dal_4/query/customers.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/customers.gen_test.go
+++ b/tests/.expect/dal_4/query/customers.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_4/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/people.gen_test.go
+++ b/tests/.expect/dal_4/query/people.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/people.gen_test.go
+++ b/tests/.expect/dal_4/query/people.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/people.gen_test.go
+++ b/tests/.expect/dal_4/query/people.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_4/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/users.gen_test.go
+++ b/tests/.expect/dal_4/query/users.gen_test.go
@@ -13,8 +13,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/users.gen_test.go
+++ b/tests/.expect/dal_4/query/users.gen_test.go
@@ -13,8 +13,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_4/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_4/model"
 )
 
 func init() {

--- a/tests/.expect/dal_4/query/users.gen_test.go
+++ b/tests/.expect/dal_4/query/users.gen_test.go
@@ -13,9 +13,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_4/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_5/query/users.gen_test.go
+++ b/tests/.expect/dal_5/query/users.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_5/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_5/model"
 )
 
 func init() {

--- a/tests/.expect/dal_5/query/users.gen_test.go
+++ b/tests/.expect/dal_5/query/users.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_5/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_5/model"
 )
 
 func init() {

--- a/tests/.expect/dal_5/query/users.gen_test.go
+++ b/tests/.expect/dal_5/query/users.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_5/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {

--- a/tests/.expect/dal_6/query/users.gen_test.go
+++ b/tests/.expect/dal_6/query/users.gen_test.go
@@ -11,8 +11,9 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_6/model"
 	"gorm.io/gorm/clause"
+
+	"gorm.io/gen/tests/.gen/dal_6/model"
 )
 
 func init() {

--- a/tests/.expect/dal_6/query/users.gen_test.go
+++ b/tests/.expect/dal_6/query/users.gen_test.go
@@ -11,8 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gen/tests/.gen/dal_6/model"
 	"gorm.io/gorm/clause"
+	"gorm.io/gen/tests/.gen/dal_6/model"
 )
 
 func init() {

--- a/tests/.expect/dal_6/query/users.gen_test.go
+++ b/tests/.expect/dal_6/query/users.gen_test.go
@@ -11,9 +11,8 @@ import (
 
 	"gorm.io/gen"
 	"gorm.io/gen/field"
-	"gorm.io/gorm/clause"
-
 	"gorm.io/gen/tests/.gen/dal_6/model"
+	"gorm.io/gorm/clause"
 )
 
 func init() {


### PR DESCRIPTION
…nterface definitions.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

- Extend the object interface in the helper and add the mehtod method.
- Added Interface interface in helper for customizing query interface

### User Case Description

In some scenarios, I need to dynamically build modules and queries through code instead of relying on the target code to compile and run (such as parsing go code files through ast or other methods). Here are my use cases:

```go
	g := gen.NewGenerator(cfg)
	obj, err := sql.ParseFromStruct("./example/model_user.go", "TblUser")
	if err != nil {
		panic(err)
	}
	g.ApplyInterface(sql.Interface{
		IfName: "query",
		IfMethods: []sql.Method{{
			MethodName: "GetUser",
			Doc:        "SELECT * FROM @@table WHERE xxx=1",
		}}}, g.GenerateModelFrom(obj))

	g.Execute()
```

