### PR TITLE
fix: allow overriding existing meta

### DIFF
--- a/field/time.go
+++ b/field/time.go
@@ -119,6 +119,11 @@ func (field Time) Month() Int {
 	return Int{expr{e: clause.Expr{SQL: "MONTH(?)", Vars: []interface{}{field.RawExpr()}}}}
 }
 
+// Week equal to WEEK(self)
+func (field Time) Week() Int {
+	return Int{expr{e: clause.Expr{SQL: "WEEK(?)", Vars: []interface{}{field.RawExpr()}}}}
+}
+
 // Day equal to DAY(self)
 func (field Time) Day() Int {
 	return Int{expr{e: clause.Expr{SQL: "DAY(?)", Vars: []interface{}{field.RawExpr()}}}}

--- a/field/time.go
+++ b/field/time.go
@@ -120,8 +120,8 @@ func (field Time) Month() Int {
 }
 
 // Week equal to WEEK(self)
-func (field Time) Week() Int {
-	return Int{expr{e: clause.Expr{SQL: "WEEK(?)", Vars: []interface{}{field.RawExpr()}}}}
+func (field Time) Week(mode int) Int {
+	return Int{expr{e: clause.Expr{SQL: fmt.Sprintf("WEEK(?, %d)", mode), Vars: []interface{}{field.RawExpr()}}}}
 }
 
 // Day equal to DAY(self)

--- a/generator.go
+++ b/generator.go
@@ -571,13 +571,13 @@ func (g *Generator) output(fileName string, content []byte) error {
 
 func (g *Generator) pushQueryStructMeta(meta *generate.QueryStructMeta) (*genInfo, error) {
 	structName := meta.ModelStructName
-	if g.Data[structName] == nil {
-		g.Data[structName] = &genInfo{QueryStructMeta: meta}
+	if v, ok := g.Data[structName]; ok {
+		if v.Source != meta.Source {
+			return nil, fmt.Errorf("cannot generate struct with the same name from different source:%s.%s and %s.%s",
+				meta.StructInfo.Package, meta.ModelStructName, g.Data[structName].StructInfo.Package, g.Data[structName].ModelStructName)
+		}
 	}
-	if g.Data[structName].Source != meta.Source {
-		return nil, fmt.Errorf("cannot generate struct with the same name from different source:%s.%s and %s.%s",
-			meta.StructInfo.Package, meta.ModelStructName, g.Data[structName].StructInfo.Package, g.Data[structName].ModelStructName)
-	}
+	g.Data[structName] = &genInfo{QueryStructMeta: meta}
 	return g.Data[structName], nil
 }
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
allow overriding existing meta
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
```
g.ApplyBasic(g.GenerateAllTable()...)

permissions := g.GenerateModel("sys_permissions")
roles := g.GenerateModel("sys_roles", gen.FieldRelate(field.Many2Many, "Permissions", permissions,
  &field.RelateConfig{
	GORMTag: field.GormTag{
		"many2many": []string{"role_permissions"},
	},
}))
g.ApplyBasic(roles)
```
<!-- Your use case -->
