### PR TITLE
feat: support RANDOM()

### DIFF
--- a/field/function.go
+++ b/field/function.go
@@ -30,3 +30,7 @@ func (f *function) FromUnixTime(date uint64, format string) String {
 func (f *function) Rand() String {
 	return String{expr{e: clause.Expr{SQL: "RAND()"}}}
 }
+
+func (f *function) Random() String {
+	return String{expr{e: clause.Expr{SQL: "RANDOM()"}}}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

Added support for field.Func.Random() to enable compatibility with PostgreSQL.

### User Case Description

This pull request introduces support for field.Func.Random(). Previously, `RAND()` was available through `field.Func.Rand()` (#901), which wasn’t compatible with PostgreSQL. This update makes it straightforward to use RANDOM() for PostgreSQL by `field.Func.Random()` in a similar manner.