### PR TITLE
fix: 字段名称转换误用SchemaName,修正为ColumnName

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -33,9 +33,9 @@ func getFields(db *gorm.DB, conf *model.Config, columns []*model.Column) (fields
 		m = modifyField(m, conf.ModifyOpts)
 		if ns, ok := db.NamingStrategy.(schema.NamingStrategy); ok {
 			ns.SingularTable = true
-			m.Name = ns.SchemaName(ns.TablePrefix + m.Name)
+			m.Name = ns.ColumnName("", m.Name)
 		} else if db.NamingStrategy != nil {
-			m.Name = db.NamingStrategy.SchemaName(m.Name)
+			m.Name = db.NamingStrategy.ColumnName("", m.Name)
 		}
 
 		fields = append(fields, m)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
遇到了这个问题 [issues/969](https://github.com/go-gorm/gen/issues/969)，通过gorm gen转换后发现原来SQL字段名称中的下划线消失了，导致了比如"X_Y"和"XY"都转换成了"XY"，最终的Model里面有两个同名的字段。

查看源码后发现在转换字段时，貌似误用了SchemaName()函数，修改为ColumnName()就没问题了。

### User Case Description
SQL DDL:
``` sql
CREATE TABLE XXX (
	STOCKUNIT numeric(1,0) NOT NULL,
	STOCK_UNIT nvarchar(20) COLLATE Latin1_General_BIN NOT NULL,
	...
)
```

修改前生成的Model:
``` go
// PRICE mapped from table <PRICE>
type PRICE struct {
	STOCKUNIT  int32     `gorm:"column:STOCKUNIT;type:numeric;not null" json:"STOCKUNIT"`
	STOCKUNIT string    `gorm:"column:STOCK_UNIT;type:nvarchar;not null" json:"STOCK_UNIT"`
	...
}
```

修改后生成的Model:
``` go
// PRICE mapped from table <PRICE>
type PRICE struct {
	STOCKUNIT  int32     `gorm:"column:STOCKUNIT;type:numeric;not null" json:"STOCKUNIT"`
	STOCK_UNIT string    `gorm:"column:STOCK_UNIT;type:nvarchar;not null" json:"STOCK_UNIT"`
	...
}
```