### PR TITLE
fix: missing the relations for the main model while using on other model.

### DIFF
--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -217,7 +217,7 @@ func BuildDIYMethod(f *parser.InterfaceSet, s *QueryStructMeta, data []*Interfac
 // ParseStructRelationShip parse struct's relationship
 // No one should use it directly in project
 func ParseStructRelationShip(relationship *schema.Relationships) []field.Relation {
-	cache := make(map[string]bool)
+	cache := make(map[string][]field.Relation)
 	return append(append(append(append(
 		make([]field.Relation, 0, 4),
 		pullRelationShip(cache, relationship.HasOne)...),


### PR DESCRIPTION
Fix the missing relations of the main model while containing the child model trying mapping to parent.

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

```go
AdminUser -> TwoFaTokens -> AdminUser
AdminUser -> TwoFaDevices -> AdminUser
AdminUser -> LoginHistory -> AdminUser
AdminUser -> Roles -> Permissions
```


```go
		uQ := s.app.Query.AdminUser
		uR, err = uQ.
			Preload(
				uQ.PermissionsJoin,
				uQ.Roles.Permissions,  // This fix allow calling like this.
			).
			Where(uQ.Email.Eq(email)).
			First()
```

### User Case Description

There is missing the relations  `AdminUser -> Roles -> Permissions`. Because, The relation: TwoFaTokens/TwoFaDevices/LoginHistory calling to AdminUser and set relations of AdminUser -> Role with is empty relations.

I'm tried with the design:
```go
// BaseUser struct
// Define common fields for both Seeker, Giver and AdminUser
type BaseUser struct {
	ID                 uint64     `gorm:"primaryKey" json:"id"`
	Email              string     `gorm:"uniqueIndex" json:"email"`
	Password           string     `json:"-"`
	FirstName          string     `json:"firstName"`
	LastName           string     `json:"lastName"`
	PasswordResetToken *string    `json:"-"`
	ResetTokenExpire   *time.Time `json:"-"`
}

type AdminUser struct {
	BaseUser
	TwoFaTokens  *[]AdminUserTwoFaToken   `json:"-" gorm:"constraint:OnDelete:CASCADE;"`
	TwoFaDevices *[]AdminUserTwoFaDevice  `json:"-" gorm:"constraint:OnDelete:CASCADE;"`
	LoginHistory *[]AdminUserLoginHistory `json:"-" gorm:"constraint:OnDelete:CASCADE;"`

	Permissions     *[]AdminPermission     `json:"-" gorm:"many2many:AdminUserPermission;constraint:OnDelete:CASCADE;"`
	Roles           *[]AdminRole           `json:"-" gorm:"many2many:AdminUserRole;constraint:OnDelete:CASCADE;"`
}


type AdminRole struct {
	ID              uint64                 `json:"id" gorm:"primaryKey;autoIncrement"`
	Name            string                 `json:"name"`
	Permissions     *[]AdminPermission     `json:"permissions" gorm:"many2many:AdminRolePermission;constraint:OnDelete:CASCADE;"`
}

type AdminPermission struct {
	Key string `gorm:"primarykey"`
}

type AdminUserLoginHistory struct {
	ID         uint64  `json:"id" gorm:"primaryKey"`
	DeviceName *string `json:"deviceName"`
	DeviceIp   *string `json:"deviceIp"`
	Status     int8    `json:"status"`
	AdminUserID uint64     `json:"adminUserId" gorm:"index"`
	AdminUser   *AdminUser `json:"-" gorm:"foreignKey:AdminUserID;constraint:OnDelete:CASCADE"`
}

type AdminUserSocialAccount struct {
	ID           uint64     `json:"id" gorm:"primaryKey"`
	Provider     string     `json:"provider"`
	ProviderID   string     `json:"providerId"`
	AccessToken  *string    `json:"accessToken"`
	RefreshToken *string    `json:"refreshToken"`
	AdminUserID uint64     `json:"adminUserId" gorm:"index"`
	AdminUser   *AdminUser `json:"-" gorm:"foreignKey:AdminUserID;constraint:OnDelete:CASCADE"`
}

type AdminUserTwoFaToken struct {
	ID          uint64  `json:"id" gorm:"primaryKey"`
	OtpType     uint    `json:"otpType"`
	Secret      string  `json:"-"`
	Extra       *string `json:"extra"`
	BackupCodes *string `json:"-"`
	AdminUserID uint64     `json:"adminUserId" gorm:"index"`
	AdminUser   *AdminUser `json:"-" gorm:"foreignKey:AdminUserID;constraint:OnDelete:CASCADE"`
}

type AdminUserTwoFaDevice struct {
	ID          uint64 `json:"id" gorm:"primaryKey"`
	DeviceName  string `json:"deviceName"`
	DeviceToken string `json:"-"`
	AdminUserID uint64     `json:"adminUserId" gorm:"index"`
	AdminUser   *AdminUser `json:"-" gorm:"foreignKey:AdminUserID;constraint:OnDelete:CASCADE"`
}

```