### PR TITLE
fix: fix context propagation in UseDB method

### DIFF
--- a/do.go
+++ b/do.go
@@ -50,9 +50,9 @@ var (
 
 // UseDB specify a db connection(*gorm.DB)
 func (d *DO) UseDB(db *gorm.DB, opts ...DOOption) {
-	ctx := db.Statement.Context
-	if ctx == nil {
-		ctx = context.Background()
+	ctx := context.Background()
+	if db.Statement != nil && db.Statement.Context != nil {
+		ctx = db.Statement.Context
 	}
 	db = db.Session(&gorm.Session{Context: ctx})
 	d.db = db

--- a/do.go
+++ b/do.go
@@ -50,7 +50,11 @@ var (
 
 // UseDB specify a db connection(*gorm.DB)
 func (d *DO) UseDB(db *gorm.DB, opts ...DOOption) {
-	db = db.Session(&gorm.Session{Context: context.Background()})
+	ctx := db.Statement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	db = db.Session(&gorm.Session{Context: ctx})
 	d.db = db
 	config := &DOConfig{}
 	for _, opt := range opts {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested (CI and Local)

### What did this pull request do?

First and foremost, Thank you for creating this great project.

#### WHAT

The issue where the context was always set to `context.Background()` in the UseDB method has been fixed. Previously, when performing database operations, the original context (including cancellation and timeout) was ignored, and a new `context.Background()` was always used. After the fix, the method now uses `db.Statement.Context` to propagate the existing context. If no context is set, it defaults to `context.Background()`.

In the following example, even though the context (ctx) was passed from the higher layer, the original context was not properly propagated in the previous implementation:

```go
t := query.Use(r.db.WithContext(ctx)).Tenant
tenant, err := t.Where(t.ID.Eq(id)).First()
```

#### WHY

By always setting the context to `context.Background()`, the original context's cancellation and timeout settings were not applied to the database queries, leading to potential issues with request timeouts or cancellations not being respected. This fix ensures that the cancellation and timeout of the context are properly propagated, allowing database operations to be influenced by the context. This will ensure that when a context is passed from a higher layer, like in the example above, it will correctly reflect cancellations or timeouts.

### User Case Description

<!-- Your use case -->
