### PR TITLE
fix:default value is '' or 0

### DIFF
--- a/internal/model/tbl_column.go
+++ b/internal/model/tbl_column.go
@@ -111,9 +111,11 @@ func (c *Column) buildGormTag() field.GormTag {
 		}
 	}
 
-	if dtValue := c.defaultTagValue(); c.needDefaultTag(dtValue) { // cannot set default tag for primary key
+	if _, valid := c.DefaultValue(); valid {
+		dtValue := c.defaultTagValue()
 		tag.Set(field.TagKeyGormDefault, dtValue)
 	}
+
 	if comment, ok := c.Comment(); ok && comment != "" {
 		if c.multilineComment() {
 			comment = strings.ReplaceAll(comment, "\n", "\\n")
@@ -149,6 +151,9 @@ func (c *Column) defaultTagValue() string {
 	}
 	if value != "" && strings.TrimSpace(value) == "" {
 		return "'" + value + "'"
+	}
+	if value == "" {
+		return "''"
 	}
 	return value
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

When the default value of the database field is 0 or "", the default tag will still be generated.

### User Case Description

1. Problem background 
 
In the database model definition, the default tag of gorm is used to specify the default value of the field. The current method does not generate the default tag when dealing with the empty string "" and the value of 0, resulting in the generated structure not meeting expectations. 
 
2. Modify the content 
 
New logic: When value == "", return "" "(i.e., the SQL empty string literal), remove the detection of 0 values, and ensure that the value of the default tag of the generated struct is correct.
