### PR TITLE
fix: fix unstable tag generation for composite indexes with different column orders

### DIFF
--- a/internal/model/tbl_column.go
+++ b/internal/model/tbl_column.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"gorm.io/gen/field"
@@ -97,11 +98,18 @@ func (c *Column) buildGormTag() field.GormTag {
 		tag.Set(field.TagKeyGormNotNull, "")
 	}
 
-	for _, idx := range c.Indexes {
+	// Create a copy of indexes and sort by name to ensure consistent order
+	indexes := make([]*Index, len(c.Indexes))
+	copy(indexes, c.Indexes)
+	sort.Slice(indexes, func(i, j int) bool {
+		return indexes[i].Name() < indexes[j].Name()
+	})
+
+	for _, idx := range indexes {
 		if idx == nil {
 			continue
 		}
-		if pk, _ := idx.PrimaryKey(); pk { //ignore PrimaryKey
+		if pk, _ := idx.PrimaryKey(); pk { // ignore PrimaryKey
 			continue
 		}
 		if uniq, _ := idx.Unique(); uniq {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Fix unstable tag generation for composite indexes with different column orders.

### User Case Description

<!-- Your use case -->

When multiple composite indexes exist on the same columns but in different orders, the generated code may have unstable tag output.

Example.

```sql
CREATE TABLE users (
    id INT PRIMARY KEY,
    email VARCHAR(255),
    name VARCHAR(255),

    -- composite indexes with different column orders
    INDEX idx_email_name (email, name),
    INDEX idx_name_email (name, email)
);
```

With a schema like the above, the generated tags can vary between runs:

```go
// First run
Email string `gorm:"index:idx_email_name,priority:1;index:idx_name_email,priority:2"`

// Second run (order may differ)
Email string `gorm:"index:idx_name_email,priority:2;index:idx_email_name,priority:1"`
```

