### PR TITLE
feat: ignore nil AssignExpr

### DIFF
--- a/do.go
+++ b/do.go
@@ -776,6 +776,9 @@ func (d *DO) UpdateColumns(value interface{}) (info ResultInfo, err error) {
 // assignSet fetch all set
 func (d *DO) assignSet(exprs []field.AssignExpr) (set clause.Set) {
 	for _, expr := range exprs {
+		if expr == nil {
+			continue
+		}
 		column := clause.Column{Table: d.alias, Name: string(expr.ColumnName())}
 		switch e := expr.AssignExpr().(type) {
 		case clause.Expr:


### PR DESCRIPTION
UpdateSimple, UpdateColumnSimple的columns参数传入nil时会panic, 希望和Where方法保持一致，生成clause时过滤掉nil

related issue:
https://github.com/go-gorm/gen/issues/1358