### PR TITLE
fix: ensure deterministic index order in generated models

### DIFF
--- a/internal/model/tbl_column.go
+++ b/internal/model/tbl_column.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"gorm.io/gen/field"
@@ -98,7 +99,14 @@ func (c *Column) buildGormTag() field.GormTag {
 		tag.Set(field.TagKeyGormNotNull, "")
 	}
 
-	for _, idx := range c.Indexes {
+	// Sort indexes by name to ensure deterministic order
+	sortedIndexes := make([]*Index, len(c.Indexes))
+	copy(sortedIndexes, c.Indexes)
+	sort.Slice(sortedIndexes, func(i, j int) bool {
+		return sortedIndexes[i].Name() < sortedIndexes[j].Name()
+	})
+
+	for _, idx := range sortedIndexes {
 		if idx == nil {
 			continue
 		}


### PR DESCRIPTION
Sort indexes by name before generating GORM tags to ensure consistent output across multiple code generation runs.

This fixes the issue where index order in generated models was non-deterministic, causing CI diffs on each generation.

Fixes: #1409

<!--

Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.

-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR fixes the non-deterministic index order issue in generated GORM models. Previously, when generating models with multiple indexes on the same column, the order of indexes in the GORM tag could vary between generation runs, causing unnecessary diffs in CI/CD pipelines.

**Changes:**
- Added sorting of indexes by name in `buildGormTag()` method in `internal/model/tbl_column.go`
- Imported `sort` package to enable index sorting
- Indexes are now sorted alphabetically by name before being added to GORM tags, ensuring consistent output

**Example:**
Before this fix, a column with indexes `idx_payout_tenant_payment_at` and `idx_payout_tenant_id` could generate tags in different orders:
- Sometimes: `index:idx_payout_tenant_id,priority:1;index:idx_payout_tenant_payment_at,priority:2`
- Sometimes: `index:idx_payout_tenant_payment_at,priority:2;index:idx_payout_tenant_id,priority:1`

After this fix, the order is always deterministic (alphabetical):
- Always: `index:idx_payout_tenant_id,priority:1;index:idx_payout_tenant_payment_at,priority:2`

### User Case Description

**Problem:**
When using GORM gen to generate models, the index order in generated GORM tags was non-deterministic. This caused CI/CD pipelines to fail with false-positive diffs on every code generation run, even when the actual database schema hadn't changed.

**Use Case:**
1. Developer runs `gen` to generate models from database schema
2. Models are committed to version control
3. CI/CD pipeline runs the same generation command
4. CI fails because the generated file has different index order (even though functionally identical)
5. Developer has to manually commit the "updated" file, creating unnecessary noise in git history

**Solution:**
By sorting indexes alphabetically by name before generating tags, the output is now deterministic and consistent across all generation runs, eliminating false-positive CI diffs.
