### PR TITLE
feat(gen): support custom templates for model generation

### DIFF
--- a/field_options.go
+++ b/field_options.go
@@ -321,6 +321,11 @@ var (
 	WithMethod = func(methods ...interface{}) model.AddMethodOpt {
 		return func() []interface{} { return methods }
 	}
+
+	// WithTemplate add custom template text for table model
+	WithTemplate = func(templates ...string) model.AddTemplateOpt {
+		return func() []string { return templates }
+	}
 )
 
 var (

--- a/generator.go
+++ b/generator.go
@@ -238,12 +238,6 @@ func (g *Generator) ApplyInterface(fc interface{}, models ...interface{}) {
 	g.apply(fc, structs)
 }
 
-func (g *Generator) ApplyCustomTemplateForModel(templateText string) {
-	for _, modelMeta := range g.models {
-		modelMeta.CustomTemplates = append(modelMeta.CustomTemplates, templateText)
-	}
-}
-
 func (g *Generator) apply(fc interface{}, structs []*generate.QueryStructMeta) {
 	interfacePaths, err := parser.GetInterfacePath(fc)
 	if err != nil {

--- a/generator.go
+++ b/generator.go
@@ -238,6 +238,12 @@ func (g *Generator) ApplyInterface(fc interface{}, models ...interface{}) {
 	g.apply(fc, structs)
 }
 
+func (g *Generator) ApplyCustomTemplateForModel(templateText string) {
+	for _, modelMeta := range g.models {
+		modelMeta.CustomTemplates = append(modelMeta.CustomTemplates, templateText)
+	}
+}
+
 func (g *Generator) apply(fc interface{}, structs []*generate.QueryStructMeta) {
 	interfacePaths, err := parser.GetInterfacePath(fc)
 	if err != nil {
@@ -659,6 +665,13 @@ modelLoop:
 			if err := render(tmpl.Model, &buf, data); err != nil {
 				errs.Abort(err)
 				return
+			}
+
+			for _, customTemplate := range data.CustomTemplates {
+				if err := render(customTemplate, &buf, data); err != nil {
+					errs.Abort(err)
+					return
+				}
 			}
 
 			for _, method := range data.ModelMethods {

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -53,7 +53,7 @@ func GetQueryStructMeta(db *gorm.DB, conf *model.Config) (*QueryStructMeta, erro
 		StructInfo:            parser.Param{Type: structName, Package: conf.ModelPkg},
 		ImportPkgPaths:        conf.ImportPkgPaths,
 		Fields:                getFields(db, conf, columns),
-	}).addMethodFromAddMethodOpt(conf.GetModelMethods()...), nil
+	}).addMethodFromAddMethodOpt(conf.GetModelMethods()...).addCustomTemplateFromOpt(conf.GetCustomTemplates()...), nil
 }
 
 // GetQueryStructMetaFromObject generate base struct from object

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -275,6 +275,11 @@ func (b *QueryStructMeta) addMethodFromAddMethodOpt(methods ...interface{}) *Que
 	return b
 }
 
+func (b *QueryStructMeta) addCustomTemplateFromOpt(templates ...string) *QueryStructMeta {
+	b.CustomTemplates = append(b.CustomTemplates, templates...)
+	return b
+}
+
 // IfaceMode object mode
 func (b QueryStructMeta) IfaceMode(on bool) *QueryStructMeta {
 	b.interfaceMode = on

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -40,8 +40,9 @@ type QueryStructMeta struct {
 	Fields                []*model.Field   // normalized model and relationship fields
 	Source                model.SourceCode // generated model source, when model generation is enabled
 	// ImportPkgPaths contains additional quoted imports required by generated code.
-	ImportPkgPaths []string
-	ModelMethods   []*parser.Method // user custom method bind to db base struct
+	ImportPkgPaths  []string
+	ModelMethods    []*parser.Method // user custom method bind to db base struct
+	CustomTemplates []string         // custom template text
 
 	interfaceMode bool
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	NameStrategy
 	FieldConfig
 	MethodConfig
+	TemplateConfig
 }
 
 // NameStrategy name strategy
@@ -55,6 +56,11 @@ type MethodConfig struct {
 	MethodOpts []MethodOption
 }
 
+// TemplateConfig custom template configuration
+type TemplateConfig struct {
+	TemplateOpts []TemplateOption
+}
+
 // Preprocess revise invalid field
 func (cfg *Config) Preprocess() *Config {
 	if cfg.ModelPkg == "" {
@@ -62,7 +68,7 @@ func (cfg *Config) Preprocess() *Config {
 	}
 	cfg.ModelPkg = filepath.Base(cfg.ModelPkg)
 
-	cfg.ModifyOpts, cfg.FilterOpts, cfg.CreateOpts, cfg.MethodOpts = sortOptions(cfg.ModelOpts)
+	cfg.ModifyOpts, cfg.FilterOpts, cfg.CreateOpts, cfg.MethodOpts, cfg.TemplateOpts = sortOptions(cfg.ModelOpts)
 
 	return cfg
 }
@@ -98,6 +104,18 @@ func (cfg *Config) GetModelMethods() (methods []interface{}) {
 
 	for _, opt := range cfg.MethodOpts {
 		methods = append(methods, opt.Methods()...)
+	}
+	return
+}
+
+// GetCustomTemplates get diy custom template from option
+func (cfg *Config) GetCustomTemplates() (templates []string) {
+	if cfg == nil {
+		return
+	}
+
+	for _, opt := range cfg.TemplateOpts {
+		templates = append(templates, opt.Templates()...)
 	}
 	return
 }

--- a/internal/model/options.go
+++ b/internal/model/options.go
@@ -28,12 +28,22 @@ type MethodOption interface {
 	Methods() (methods []interface{})
 }
 
+const templateType = "template"
+
+// TemplateOption ...
+type TemplateOption interface {
+	Option
+	Templates() (templates []string)
+}
+
 var (
 	_ Option = ModifyFieldOpt(nil)
 	_ Option = FilterFieldOpt(nil)
 	_ Option = CreateFieldOpt(nil)
 
 	_ Option = AddMethodOpt(nil)
+
+	_ Option = AddTemplateOpt(nil)
 )
 
 // ModifyFieldOpt modify field option
@@ -72,7 +82,16 @@ func (AddMethodOpt) OptionType() string { return methodType }
 // Methods ...
 func (o AddMethodOpt) Methods() []interface{} { return o() }
 
-func sortOptions(opts []Option) (modifyOpts []FieldOption, filterOpts []FieldOption, createOpts []FieldOption, methodOpt []MethodOption) {
+// AddTemplateOpt diy template option
+type AddTemplateOpt func() (templates []string)
+
+// OptionType implement for interface Option
+func (AddTemplateOpt) OptionType() string { return templateType }
+
+// Templates ...
+func (o AddTemplateOpt) Templates() []string { return o() }
+
+func sortOptions(opts []Option) (modifyOpts []FieldOption, filterOpts []FieldOption, createOpts []FieldOption, methodOpt []MethodOption, templateOpts []TemplateOption) {
 	for _, opt := range opts {
 		switch opt := opt.(type) {
 		case ModifyFieldOpt:
@@ -83,6 +102,8 @@ func sortOptions(opts []Option) (modifyOpts []FieldOption, filterOpts []FieldOpt
 			createOpts = append(createOpts, opt)
 		case AddMethodOpt:
 			methodOpt = append(methodOpt, opt)
+		case AddTemplateOpt:
+			templateOpts = append(templateOpts, opt)
 		}
 	}
 	return

--- a/tests/generate_test.go
+++ b/tests/generate_test.go
@@ -340,3 +340,33 @@ func Test_GenVariadic(t *testing.T) {
 		t.Error("should generate VariadicMethod implementation")
 	}
 }
+
+func Test_GenWithTemplate(t *testing.T) {
+	dir := ".gen/with_template_test"
+	os.RemoveAll(dir)
+	g := gen.NewGenerator(gen.Config{
+		OutPath: dir + "/query",
+		Mode:    gen.WithDefaultQuery,
+	})
+	g.UseDB(DB)
+	g.ApplyBasic(g.GenerateModel("users", gen.WithTemplate(`
+// CustomHello says hello for {{.ModelStructName}}
+func ({{.S}} *{{.ModelStructName}}) CustomHello() string {
+	return "hello from {{.ModelStructName}}"
+}
+`)))
+	g.Execute()
+
+	modelFile := dir + "/model/users.gen.go"
+	content, err := os.ReadFile(modelFile)
+	if err != nil {
+		t.Fatalf("read generated file failed: %v", err)
+	}
+	str := string(content)
+	if !strings.Contains(str, "func (u *User) CustomHello() string {") {
+		t.Error("should render custom template into generated model file")
+	}
+	if !strings.Contains(str, `return "hello from User"`) {
+		t.Error("should render template data (ModelStructName) into custom template")
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

- This MR adds support for custom templates in the model generation process, allowing consumers to inject additional generated code (e.g. filters, helper methods, DTOs) alongside default GORM Gen outputs.
- Custom templates are exposed as a `model.Option` via `gen.WithTemplate(...)`, consistent with existing options like `gen.WithMethod(...)`. They can be applied globally (`g.WithOpts(gen.WithTemplate(...))`) or per-model (`g.GenerateModel("users", gen.WithTemplate(...))`).

### User Case Description
A typical use case is generating:

- {Model}Filter structs for dynamic query building

- Common helper methods such as ToMap() for update operations or generic payload handling
<img width="781" height="530" alt="image" src="https://github.com/user-attachments/assets/733fa838-76b6-488e-aec0-11fca2934689" />

- result
<img width="837" height="708" alt="image" src="https://github.com/user-attachments/assets/b405b04e-d279-4a7a-b71b-3f0b6a6d965d" />

### Update
- Reworked the API per review feedback: replaced the `Generator.ApplyCustomTemplateForModel` broadcast method with `gen.WithTemplate(...)`, a `ModelOpt` consistent with `gen.WithMethod`.
- Added unit tests (`internal/model/options_test.go`, `internal/model/config_test.go`) and an integration test (`Test_GenWithTemplate` in `tests/generate_test.go`) that verifies the rendered output in the generated model file.
- Merged latest `master` and resolved conflicts in `internal/generate/export.go`, `internal/generate/query.go`, and `tests/generate_test.go`.

<!-- Your use case -->
