### PR TITLE
fix: correct bind index generation for parameterized SELECT expressions in PostgreSQL

### DIFF
--- a/do.go
+++ b/do.go
@@ -894,12 +894,17 @@ func buildExpr4Select(stmt *gorm.Statement, exprs ...field.Expr) (query string, 
 		return "", nil
 	}
 
-	var queryItems []string
+	var (
+		queryItems []string
+		offset     = len(stmt.Vars)
+	)
+	newStmt := &gorm.Statement{DB: stmt.DB, Table: stmt.Table, Schema: stmt.Schema, Vars: make([]interface{}, offset)}
 	for _, e := range exprs {
-		sql, vars := e.BuildWithArgs(stmt)
+		sql, vars := e.BuildWithArgs(newStmt)
 		queryItems = append(queryItems, sql.String())
-		args = append(args, vars...)
+		newStmt.Vars = append(newStmt.Vars, vars...)
 	}
+	args = newStmt.Vars[offset:]
 	if len(args) == 0 {
 		return queryItems[0], toInterfaceSlice(queryItems[1:])
 	}

--- a/field/expr.go
+++ b/field/expr.go
@@ -136,9 +136,10 @@ func (e expr) BuildWithArgs(stmt *gorm.Statement) (sql, []interface{}) {
 	if e.e == nil {
 		return sql(e.BuildColumn(stmt, WithAll)), nil
 	}
-	newStmt := &gorm.Statement{DB: stmt.DB, Table: stmt.Table, Schema: stmt.Schema}
+	offset := len(stmt.Vars)
+	newStmt := &gorm.Statement{DB: stmt.DB, Table: stmt.Table, Schema: stmt.Schema, Vars: make([]interface{}, offset)}
 	e.e.Build(newStmt)
-	return sql(newStmt.SQL.String()), newStmt.Vars
+	return sql(newStmt.SQL.String()), newStmt.Vars[offset:]
 }
 
 func (e expr) RawExpr() expression {


### PR DESCRIPTION
* [x] Do only one thing
* [x] Non breaking API changes
* [x] Tested

### What did this pull request do?

* Fix correct bind index generation for parameterized SELECT expressions in PostgreSQL

#### Bug Fix

Previously, when multiple `field.Expr` values containing bind variables were passed into `Select(...)`, each expression was built using a new `gorm.Statement`. This caused bind indexes to restart from `$1` for every expression (PostgreSQL), producing invalid SQL such as:

```sql
SELECT $1, $1
```

instead of:

```sql
SELECT $1, $2
```

This PR fixes the issue by preserving bind index offsets across select expressions while still preventing SQL accumulation between statements.

The fix:

* Ensures continuous and correct bind index generation
* Does not change any public API
* Does not affect existing users who do not use parameterized select expressions
* Corrects previously invalid SQL behavior

This change is considered a bug fix rather than a breaking change.

### User Case Description
```go
Select(
    field.Expr("?", 1),
    field.Expr("?", 2),
)
```

Now correctly generates:

```sql
SELECT $1, $2
```

### Compatibility

* No public API changes
* No breaking behavior
* Existing non-parameterized `Select` usage unaffected
* Only fixes incorrect bind index behavior when parameters are used in select expressions
