### PR TITLE
fix: keep model for optimistic lock updates

### DIFF
--- a/do.go
+++ b/do.go
@@ -760,6 +760,10 @@ func (d *DO) prepareTx() *gorm.DB {
 	tx := d.db
 	if d.backfillData != nil {
 		tx = tx.Model(d.backfillData)
+	} else if tx.Statement != nil && tx.Statement.Model == nil {
+		if resultPtr := d.newResultPointer(); resultPtr != nil {
+			tx = tx.Model(resultPtr)
+		}
 	}
 	return tx
 }


### PR DESCRIPTION
## Summary\n- ensure update paths keep model info when backfill is empty\n- allow optimisticlock plugin to see model schema for Update/Updates(map)\n\n## Testing\n- go test ./...