### PR TITLE
feat: add ValuerNumber for valuer arithmetic

### DIFF
--- a/field/export.go
+++ b/field/export.go
@@ -66,6 +66,10 @@ func NewNumber[T constraints.Integer | constraints.Float](table, column string, 
 	return newNumber[T](expr{col: toColumn(table, column, opts...)})
 }
 
+func NewValuerNumber[T driver.Valuer](table, column string, opts ...Option) ValuerNumber[T] {
+	return newValuerNumber[T](expr{col: toColumn(table, column, opts...)})
+}
+
 // NewInt create new field for int
 func NewInt(table, column string, opts ...Option) Int {
 	return NewNumber[int](table, column, opts...)

--- a/field/export_test.go
+++ b/field/export_test.go
@@ -217,6 +217,31 @@ func TestExpr_Build(t *testing.T) {
 			Expr:   field.NewUint("", "id").Avg().As("number"),
 			Result: "AVG(`id`) AS `number`",
 		},
+	{
+		Expr:         field.NewValuerNumber[password]("t", "amount").Add(p),
+		Result:       "`t`.`amount`+?",
+		ExpectedVars: []interface{}{p},
+	},
+	{
+		Expr:         field.NewValuerNumber[password]("t", "amount").Sub(p),
+		Result:       "`t`.`amount`-?",
+		ExpectedVars: []interface{}{p},
+	},
+	{
+		Expr:         field.NewValuerNumber[password]("t", "amount").Mul(p),
+		Result:       "`t`.`amount`*?",
+		ExpectedVars: []interface{}{p},
+	},
+	{
+		Expr:         field.NewValuerNumber[password]("t", "amount").Div(p),
+		Result:       "`t`.`amount`/?",
+		ExpectedVars: []interface{}{p},
+	},
+	{
+		Expr:         field.NewValuerNumber[password]("t", "amount").Between(p, p),
+		Result:       "`t`.`amount` BETWEEN ? AND ?",
+		ExpectedVars: []interface{}{p, p},
+	},
 		{
 			Expr:         field.NewUint("", "id").Eq(10),
 			ExpectedVars: []interface{}{uint(10)},

--- a/field/number.go
+++ b/field/number.go
@@ -1,6 +1,7 @@
 package field
 
 import (
+	"database/sql/driver"
 	"golang.org/x/exp/constraints"
 	"gorm.io/gorm/clause"
 )
@@ -43,9 +44,41 @@ type Float64 = Number[float64]
 
 // ======================== number =======================
 
+func newValuerNumber[T driver.Valuer](e expr) ValuerNumber[T] {
+	return ValuerNumber[T]{genericsField: newGenerics[T](e)}
+}
+
 // newNumber build number type field
 func newNumber[T constraints.Integer | constraints.Float](e expr) Number[T] {
 	return Number[T]{genericsField: newGenerics[T](e)}
+}
+
+type ValuerNumber[T driver.Valuer] struct {
+	genericsField[T]
+}
+
+func (field ValuerNumber[T]) Between(left T, right T) Expr {
+	return field.between([]interface{}{left, right})
+}
+
+func (field ValuerNumber[T]) NotBetween(left T, right T) Expr {
+	return Not(field.Between(left, right))
+}
+
+func (field ValuerNumber[T]) Add(value T) ValuerNumber[T] {
+	return newValuerNumber[T](field.add(value))
+}
+
+func (field ValuerNumber[T]) Sub(value T) ValuerNumber[T] {
+	return newValuerNumber[T](field.sub(value))
+}
+
+func (field ValuerNumber[T]) Mul(value T) ValuerNumber[T] {
+	return newValuerNumber[T](field.mul(value))
+}
+
+func (field ValuerNumber[T]) Div(value T) ValuerNumber[T] {
+	return newValuerNumber[T](field.div(value))
 }
 
 // Number int type field


### PR DESCRIPTION
Fixes #1202

This adds ValuerNumber[T driver.Valuer] to support arithmetic on valuer-backed numeric types (e.g., decimal.Decimal) without widening Number[T]'s numeric constraints.

Changes:
- Add ValuerNumber type and NewValuerNumber constructor
- Support Between/Add/Sub/Mul/Div for valuer-backed numeric fields
- Add tests for ValuerNumber expression generation

Tests:
- go test ./field
