### PR TITLE
feat: make generated unit tests unique-aware

### DIFF
--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -137,6 +137,44 @@ func (b *QueryStructMeta) appendOrUpdateField(f *model.Field) {
 
 func (b *QueryStructMeta) appendField(f *model.Field) { b.Fields = append(b.Fields, f) }
 
+func (b *QueryStructMeta) HasUniqueIndex() bool {
+	for _, f := range b.Fields {
+		if f == nil {
+			continue
+		}
+		if len(f.GORMTag[field.TagKeyGormUniqueIndex]) > 0 {
+			return true
+		}
+		if f.Column == nil {
+			continue
+		}
+		for _, idx := range f.Column.Indexes {
+			if idx == nil {
+				continue
+			}
+			if unique, ok := idx.Unique(); ok && unique {
+				return true
+			}
+		}
+	}
+	if b.db == nil || b.TableName == "" {
+		return false
+	}
+	indexes, err := b.db.Migrator().GetIndexes(b.TableName)
+	if err != nil {
+		return false
+	}
+	for _, idx := range indexes {
+		if idx == nil {
+			continue
+		}
+		if unique, ok := idx.Unique(); ok && unique {
+			return true
+		}
+	}
+	return false
+}
+
 // HasField check if BaseStruct has fields
 func (b *QueryStructMeta) HasField() bool { return len(b.Fields) > 0 }
 

--- a/internal/template/method.go
+++ b/internal/template/method.go
@@ -298,19 +298,26 @@ func Test_{{.QueryStructName}}Query(t *testing.T) {
 		t.Error("GetFieldByName(\"\") from {{.QueryStructName}} success")
 	}
 
-	err = _do.Create(&{{.StructInfo.Package}}.{{.ModelStructName}}{})
+	item := &{{.StructInfo.Package}}.{{.ModelStructName}}{}
+	err = _do.Create(item)
 	if err != nil {
 		t.Error("create item in table <{{.TableName}}> fail:", err)
 	}
 
-	err = _do.Save(&{{.StructInfo.Package}}.{{.ModelStructName}}{})
+{{- if not .HasUniqueIndex }}
+	err = _do.Save(item)
 	if err != nil {
-		t.Error("create item in table <{{.TableName}}> fail:", err)
+		t.Error("save item in table <{{.TableName}}> fail:", err)
 	}
+{{- end }}
 
-	err = _do.CreateInBatches([]*{{.StructInfo.Package}}.{{.ModelStructName}}{ {}, {} }, 10)
+{{- if .HasUniqueIndex }}
+	err = _do.CreateInBatches([]*{{.StructInfo.Package}}.{{.ModelStructName}}{&{{.StructInfo.Package}}.{{.ModelStructName}}{}}, 10)
+{{- else }}
+	err = _do.CreateInBatches([]*{{.StructInfo.Package}}.{{.ModelStructName}}{&{{.StructInfo.Package}}.{{.ModelStructName}}{}, &{{.StructInfo.Package}}.{{.ModelStructName}}{}}, 10)
+{{- end }}
 	if err != nil {
-		t.Error("create item in table <{{.TableName}}> fail:", err)
+		t.Error("create items in table <{{.TableName}}> fail:", err)
 	}
 
 	_, err = _do.Select({{.QueryStructName}}.ALL).Take()


### PR DESCRIPTION
Fixes #1115

The generated CRUD unit test template currently inserts multiple empty records (Create/Save/CreateInBatches). For tables with UNIQUE constraints, this can fail because multiple inserts use the same zero values (e.g. "").

This PR makes the generated unit tests unique-aware:
- Detects non-primary UNIQUE indexes via schema/index metadata (including when index tags are not generated)
- When UNIQUE exists, only emits the initial Create() in the CRUD test template (avoids duplicate inserts)
- Fixes CreateInBatches pointer literals in generated test code for non-unique tables

Tests:
- go test ./...