### PR TITLE
Fix ApplyInterface interface source resolution

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -4,17 +4,18 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"text/template"
 
-	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/imports"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
@@ -571,19 +572,25 @@ func (g *Generator) getModelOutputPath() (outPath string, err error) {
 }
 
 func (g *Generator) fillModelPkgPath(filePath string) {
-	pkgs, err := packages.Load(&packages.Config{
-		Mode: packages.NeedName,
-		Dir:  filePath,
-	})
+	cmd := exec.Command("go", "list", "-json", ".")
+	cmd.Dir = filePath
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		g.db.Logger.Warn(context.Background(), "parse model pkg path fail: %s", err)
+		g.db.Logger.Warn(context.Background(), "parse model pkg path fail: %s", bytes.TrimSpace(output))
 		return
 	}
-	if len(pkgs) == 0 {
-		g.db.Logger.Warn(context.Background(), "parse model pkg path fail: got 0 packages")
+	var pkg struct {
+		ImportPath string `json:"ImportPath"`
+	}
+	if unmarshalErr := json.Unmarshal(output, &pkg); unmarshalErr != nil {
+		g.db.Logger.Warn(context.Background(), "parse model pkg path fail: %s", unmarshalErr)
 		return
 	}
-	g.Config.modelPkgPath = pkgs[0].PkgPath
+	if pkg.ImportPath == "" {
+		g.db.Logger.Warn(context.Background(), "parse model pkg path fail: got empty import path")
+		return
+	}
+	g.Config.modelPkgPath = pkg.ImportPath
 }
 
 // output format and output

--- a/internal/parser/export.go
+++ b/internal/parser/export.go
@@ -1,15 +1,16 @@
 package parser
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"go/build"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
-
-	"golang.org/x/tools/go/packages"
 )
 
 // InterfacePath interface path
@@ -38,8 +39,13 @@ func GetInterfacePath(v interface{}) (paths []*InterfacePath, err error) {
 			path.Name = n
 		}
 
-		cfg := &packages.Config{Mode: packages.NeedFiles}
-		var pkgs []*packages.Package
+		type goListPackage struct {
+			Dir        string   `json:"Dir"`
+			GoFiles    []string `json:"GoFiles"`
+			ImportPath string   `json:"ImportPath"`
+		}
+		var pkg goListPackage
+		var output []byte
 		if strings.Split(arg.String(), ".")[0] == "main" {
 			var skip int
 			var file string
@@ -50,24 +56,24 @@ func GetInterfacePath(v interface{}) (paths []*InterfacePath, err error) {
 				}
 				skip++
 			}
-			cfg.Dir = filepath.Dir(file)
-			pkgs, err = packages.Load(cfg, ".")
+			cmd := exec.Command("go", "list", "-json", ".")
+			cmd.Dir = filepath.Dir(file)
+			output, err = cmd.CombinedOutput()
 		} else {
-			pkgs, err = packages.Load(cfg, arg.PkgPath())
+			cmd := exec.Command("go", "list", "-json", arg.PkgPath())
+			output, err = cmd.CombinedOutput()
 		}
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("go list package %s fail: %w\n%s", arg.PkgPath(), err, bytes.TrimSpace(output))
 		}
-		if len(pkgs) == 0 {
-			return nil, fmt.Errorf("interface package not found:%s", arg.PkgPath())
+		if unmarshalErr := json.Unmarshal(output, &pkg); unmarshalErr != nil {
+			return nil, fmt.Errorf("parse go list output for %s fail: %w", arg.PkgPath(), unmarshalErr)
 		}
-		if len(pkgs[0].Errors) > 0 {
-			return nil, fmt.Errorf("load package %s fail: %w", arg.PkgPath(), pkgs[0].Errors[0])
-		}
-		path.Package = pkgs[0].PkgPath
-		for _, file := range pkgs[0].GoFiles {
-			if fileExists(file) {
-				path.Files = append(path.Files, file)
+		path.Package = pkg.ImportPath
+		for _, f := range pkg.GoFiles {
+			goFile := filepath.Join(pkg.Dir, f)
+			if fileExists(goFile) {
+				path.Files = append(path.Files, goFile)
 			}
 		}
 

--- a/internal/parser/export.go
+++ b/internal/parser/export.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+
+	"golang.org/x/tools/go/packages"
 )
 
 // InterfacePath interface path
@@ -36,24 +38,36 @@ func GetInterfacePath(v interface{}) (paths []*InterfacePath, err error) {
 			path.Name = n
 		}
 
-		ctx := build.Default
-		var p *build.Package
-
+		cfg := &packages.Config{Mode: packages.NeedFiles}
+		var pkgs []*packages.Package
 		if strings.Split(arg.String(), ".")[0] == "main" {
-			_, file, _, _ := runtime.Caller(3)
-			p, err = ctx.ImportDir(filepath.Dir(file), build.ImportComment)
+			var skip int
+			var file string
+			for {
+				_, file, _, _ = runtime.Caller(skip)
+				if !(strings.Contains(file, "gorm/gen/generator.go") || strings.Contains(file, "gorm/gen/internal")) || file == "" {
+					break
+				}
+				skip++
+			}
+			cfg.Dir = filepath.Dir(file)
+			pkgs, err = packages.Load(cfg, ".")
 		} else {
-			p, err = ctx.Import(arg.PkgPath(), "", build.ImportComment)
+			pkgs, err = packages.Load(cfg, arg.PkgPath())
 		}
-
 		if err != nil {
-			return
+			return nil, err
 		}
-
-		for _, file := range p.GoFiles {
-			goFile := fmt.Sprintf("%s/%s", p.Dir, file)
-			if fileExists(goFile) {
-				path.Files = append(path.Files, goFile)
+		if len(pkgs) == 0 {
+			return nil, fmt.Errorf("interface package not found:%s", arg.PkgPath())
+		}
+		if len(pkgs[0].Errors) > 0 {
+			return nil, fmt.Errorf("load package %s fail: %w", arg.PkgPath(), pkgs[0].Errors[0])
+		}
+		path.Package = pkgs[0].PkgPath
+		for _, file := range pkgs[0].GoFiles {
+			if fileExists(file) {
+				path.Files = append(path.Files, file)
 			}
 		}
 

--- a/internal/parser/export.go
+++ b/internal/parser/export.go
@@ -51,7 +51,7 @@ func GetInterfacePath(v interface{}) (paths []*InterfacePath, err error) {
 			var file string
 			for {
 				_, file, _, _ = runtime.Caller(skip)
-				if !(strings.Contains(file, "gorm/gen/generator.go") || strings.Contains(file, "gorm/gen/internal")) || file == "" {
+				if file == "" || (!strings.Contains(file, "gorm/gen/generator.go") && !strings.Contains(file, "gorm/gen/internal")) {
 					break
 				}
 				skip++

--- a/internal/parser/export_test.go
+++ b/internal/parser/export_test.go
@@ -1,0 +1,34 @@
+package parser_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gorm.io/gen/internal/parser"
+	"gorm.io/gen/internal/parser/fixtures/ifaces"
+)
+
+func TestGetInterfacePath(t *testing.T) {
+	paths, err := parser.GetInterfacePath(func(testIF ifaces.TestIF, m ifaces.InsertMethod) {})
+	if err != nil {
+		t.Fatalf("GetInterfacePath error: %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d", len(paths))
+	}
+	for _, p := range paths {
+		if len(p.Files) == 0 {
+			t.Fatalf("expected files for %s, got 0", p.FullName)
+		}
+		found := false
+		for _, f := range p.Files {
+			if filepath.Base(f) == "ifaces.go" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected to find ifaces.go in files for %s", p.FullName)
+		}
+	}
+}

--- a/internal/parser/fixtures/ifaces/ifaces.go
+++ b/internal/parser/fixtures/ifaces/ifaces.go
@@ -1,9 +1,12 @@
+// Package ifaces provides importable interface fixtures for parser tests.
 package ifaces
 
+// InsertMethod is a test interface for GetInterfacePath.
 type InsertMethod interface {
 	AddUser(name string, age int) error
 }
 
+// TestIF is a test interface for GetInterfacePath.
 type TestIF interface {
 	FindByID(id int) int
 }

--- a/internal/parser/fixtures/ifaces/ifaces.go
+++ b/internal/parser/fixtures/ifaces/ifaces.go
@@ -1,0 +1,9 @@
+package ifaces
+
+type InsertMethod interface {
+	AddUser(name string, age int) error
+}
+
+type TestIF interface {
+	FindByID(id int) int
+}


### PR DESCRIPTION
## Summary
- make `ApplyInterface` interface source resolution more robust by using `go list -json` to locate the package directory and its GoFiles
- avoids relying on `go/build.Default.Import` (can be sensitive to unusual GOROOT/toolchain setups)
- avoids pulling in `golang.org/x/tools/go/packages` to reduce toolchain-compat issues in some linters

## Tests
- go test ./...