### PR TITLE
Support zero-arg method calls in DIY SQL params

### DIFF
--- a/internal/generate/clause_test.go
+++ b/internal/generate/clause_test.go
@@ -44,6 +44,22 @@ func TestClause(t *testing.T) {
 		GenerateResult []string
 	}{
 		{
+			SQL: "update @@table set modify_time=@wrong.Now() where id=@wrong.Id",
+			SplitResult: []string{
+				"\"update \"",
+				"\"users\"",
+				"\" set modify_time=\"",
+				"wrong.Now()",
+				"\" where id=\"",
+				"wrong.Id",
+			},
+			GenerateResult: []string{
+				"params = append(params,wrong.Now())",
+				"params = append(params,wrong.Id)",
+				"generateSQL.WriteString(\"update users set modify_time=? where id=? \")",
+			},
+		},
+		{
 			SQL: "select * from @@table",
 			SplitResult: []string{
 				"\"select * from \"",

--- a/internal/generate/interface.go
+++ b/internal/generate/interface.go
@@ -416,6 +416,18 @@ func (m *InterfaceMethod) sqlStateCheckAndSplit() error {
 				}
 				for ; ; i++ {
 					if strOutRange(i, sqlString) || isEnd(sqlString[i]) {
+						if !strOutRange(i, sqlString) && sqlString[i] == '(' && i+1 < len(sqlString) && sqlString[i+1] == ')' {
+							buf.WriteSQL(sqlString[i])
+							i++
+							buf.WriteSQL(sqlString[i])
+							varString := buf.Dump()
+							params, err := m.Section.checkSQLVar(varString, status, m)
+							if err != nil {
+								return fmt.Errorf("sql [%s] varable %s err:%s", sqlString, varString, err)
+							}
+							m.Section.members = append(m.Section.members, params)
+							break
+						}
 						varString := buf.Dump()
 						params, err := m.Section.checkSQLVar(varString, status, m)
 						if err != nil {


### PR DESCRIPTION
## Summary\n- allow @obj.Method() in DIY SQL templates (zero-arg)\n- add coverage for method-call params\n\n## Testing\n- go test ./internal/generate