### PR TITLE
Expose Desc/Asc on Expr interface

### DIFF
--- a/field/expr.go
+++ b/field/expr.go
@@ -36,6 +36,8 @@ type Expr interface {
 	MulCol(col Expr) Expr
 	DivCol(col Expr) Expr
 	ConcatCol(cols ...Expr) Expr
+	Desc() Expr
+	Asc() Expr
 
 	// implement Condition
 	BeCond() interface{}


### PR DESCRIPTION
## Summary\n- add Desc/Asc to Expr interface so chained column ops can order without type assertions\n\n## Testing\n- go test ./field