### PR TITLE
feat: incremental generation manifest

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	OutFile      string // query code file name, default: gen.go
 	ModelPkgPath string // generated model code's package name
 	WithUnitTest bool   // generate unit test for query code
+	Incremental  bool   // skip writing unchanged generated files (based on manifest hash)
+	MergeQuery   bool   // keep previously generated query entries (A+B) when generating subsets
 
 	// generate model global configuration
 	FieldNullable       bool // generate pointer when field is nullable

--- a/generator.go
+++ b/generator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -449,7 +450,7 @@ func (g *Generator) buildMergedQueryData(manifest *genManifest) (map[string]genM
 			mergedTables[k] = v
 		}
 		for k, v := range mergedTables {
-			if _, err := os.Stat(filepath.Join(g.OutPath, v.FileName+".gen.go")); err != nil {
+			if _, err := os.Stat(filepath.Join(g.OutPath, v.FileName+".gen.go")); err != nil && errors.Is(err, os.ErrNotExist) {
 				if _, ok := currentTables[k]; !ok {
 					delete(mergedTables, k)
 				}

--- a/generator.go
+++ b/generator.go
@@ -307,16 +307,21 @@ func (g *Generator) generateQueryFile() (err error) {
 		return fmt.Errorf("make dir outpath(%s) fail: %s", g.OutPath, err)
 	}
 
-	manifest, manifestPath, err := loadManifest(g.OutPath)
-	if err != nil {
-		return err
-	}
-	prevMode := manifest.Mode
-	if g.MergeQuery && prevMode != 0 && prevMode != uint(g.Mode) {
-		return fmt.Errorf("cannot merge query tables with different mode: previous=%d current=%d", prevMode, g.Mode)
-	}
-	manifest.Mode = uint(g.Mode)
+	manifestEnabled := g.Incremental || g.MergeQuery
+	var manifest *genManifest
+	var manifestPath string
 	var manifestMu sync.Mutex
+	if manifestEnabled {
+		manifest, manifestPath, err = loadManifest(g.OutPath)
+		if err != nil {
+			return err
+		}
+		prevMode := manifest.Mode
+		if g.MergeQuery && prevMode != 0 && prevMode != uint(g.Mode) {
+			return fmt.Errorf("cannot merge query tables with different mode: previous=%d current=%d", prevMode, g.Mode)
+		}
+		manifest.Mode = uint(g.Mode)
+	}
 
 	errChan := make(chan error)
 	pool := pools.NewPool(concurrent)
@@ -344,10 +349,12 @@ func (g *Generator) generateQueryFile() (err error) {
 	case <-pool.AsyncWaitAll():
 	}
 
-	mergedTables, dataForGenGo := g.buildMergedQueryData(manifest)
-	manifest.Tables = mergedTables
 	genForRoot := *g
-	genForRoot.Data = dataForGenGo
+	if g.MergeQuery {
+		mergedTables, dataForGenGo := g.buildMergedQueryData(manifest)
+		manifest.Tables = mergedTables
+		genForRoot.Data = dataForGenGo
+	}
 
 	// generate query file
 	var buf bytes.Buffer
@@ -370,7 +377,11 @@ func (g *Generator) generateQueryFile() (err error) {
 		return err
 	}
 
-	err = g.outputWithManifest(g.OutFile, buf.Bytes(), manifest, filepath.Base(g.OutFile), &manifestMu)
+	if manifestEnabled {
+		err = g.outputWithManifest(g.OutFile, buf.Bytes(), manifest, filepath.Base(g.OutFile), &manifestMu)
+	} else {
+		err = g.output(g.OutFile, buf.Bytes())
+	}
 	if err != nil {
 		return err
 	}
@@ -398,7 +409,11 @@ func (g *Generator) generateQueryFile() (err error) {
 			return nil
 		}
 		fileName := strings.TrimSuffix(g.OutFile, ".go") + "_test.go"
-		err = g.outputWithManifest(fileName, buf.Bytes(), manifest, filepath.Base(fileName), &manifestMu)
+		if manifestEnabled {
+			err = g.outputWithManifest(fileName, buf.Bytes(), manifest, filepath.Base(fileName), &manifestMu)
+		} else {
+			err = g.output(fileName, buf.Bytes())
+		}
 		if err != nil {
 			g.db.Logger.Error(context.Background(), "generate query unit test fail: %s", err)
 			return nil
@@ -406,8 +421,10 @@ func (g *Generator) generateQueryFile() (err error) {
 		g.info("generate unit test file: " + fileName)
 	}
 
-	if err := saveManifest(manifestPath, manifest); err != nil {
-		return err
+	if manifestEnabled {
+		if err := saveManifest(manifestPath, manifest); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -527,6 +544,9 @@ func (g *Generator) generateSingleQueryFile(data *genInfo, m *genManifest, mu *s
 
 	defer g.info(fmt.Sprintf("generate query file: %s%s%s.gen.go", g.OutPath, string(os.PathSeparator), data.FileName))
 	fileName := fmt.Sprintf("%s%s%s.gen.go", g.OutPath, string(os.PathSeparator), data.FileName)
+	if m == nil {
+		return g.output(fileName, buf.Bytes())
+	}
 	return g.outputWithManifest(fileName, buf.Bytes(), m, filepath.Base(fileName), mu)
 }
 
@@ -568,6 +588,9 @@ func (g *Generator) generateQueryUnitTestFile(data *genInfo, m *genManifest, mu 
 
 	defer g.info(fmt.Sprintf("generate unit test file: %s%s%s.gen_test.go", g.OutPath, string(os.PathSeparator), data.FileName))
 	fileName := fmt.Sprintf("%s%s%s.gen_test.go", g.OutPath, string(os.PathSeparator), data.FileName)
+	if m == nil {
+		return g.output(fileName, buf.Bytes())
+	}
 	return g.outputWithManifest(fileName, buf.Bytes(), m, filepath.Base(fileName), mu)
 }
 
@@ -586,12 +609,17 @@ func (g *Generator) generateModelFile() error {
 		return fmt.Errorf("create model pkg path(%s) fail: %s", modelOutPath, err)
 	}
 
-	manifest, manifestPath, err := loadManifest(modelOutPath)
-	if err != nil {
-		return err
-	}
-	manifest.Mode = uint(g.Mode)
+	manifestEnabled := g.Incremental
+	var manifest *genManifest
+	var manifestPath string
 	var manifestMu sync.Mutex
+	if manifestEnabled {
+		manifest, manifestPath, err = loadManifest(modelOutPath)
+		if err != nil {
+			return err
+		}
+		manifest.Mode = uint(g.Mode)
+	}
 
 	errChan := make(chan error)
 	pool := pools.NewPool(concurrent)
@@ -619,7 +647,11 @@ func (g *Generator) generateModelFile() error {
 			}
 
 			modelFile := modelOutPath + data.FileName + ".gen.go"
-			err = g.outputWithManifest(modelFile, buf.Bytes(), manifest, filepath.Base(modelFile), &manifestMu)
+			if manifestEnabled {
+				err = g.outputWithManifest(modelFile, buf.Bytes(), manifest, filepath.Base(modelFile), &manifestMu)
+			} else {
+				err = g.output(modelFile, buf.Bytes())
+			}
 			if err != nil {
 				errChan <- err
 				return
@@ -632,8 +664,10 @@ func (g *Generator) generateModelFile() error {
 	case err = <-errChan:
 		return err
 	case <-pool.AsyncWaitAll():
-		if err := saveManifest(manifestPath, manifest); err != nil {
-			return err
+		if manifestEnabled {
+			if err := saveManifest(manifestPath, manifest); err != nil {
+				return err
+			}
 		}
 		g.fillModelPkgPath(modelOutPath)
 	}

--- a/generator.go
+++ b/generator.go
@@ -311,6 +311,10 @@ func (g *Generator) generateQueryFile() (err error) {
 	if err != nil {
 		return err
 	}
+	prevMode := manifest.Mode
+	if g.MergeQuery && prevMode != 0 && prevMode != uint(g.Mode) {
+		return fmt.Errorf("cannot merge query tables with different mode: previous=%d current=%d", prevMode, g.Mode)
+	}
 	manifest.Mode = uint(g.Mode)
 	var manifestMu sync.Mutex
 
@@ -705,7 +709,6 @@ func (g *Generator) outputWithManifest(fileName string, content []byte, m *genMa
 	if g.Incremental {
 		mu.Lock()
 		old := m.Files[key]
-		m.Files[key] = hash
 		mu.Unlock()
 		if old == hash {
 			if _, err := os.Stat(fileName); err == nil {
@@ -713,12 +716,17 @@ func (g *Generator) outputWithManifest(fileName string, content []byte, m *genMa
 			}
 		}
 	} else {
-		mu.Lock()
-		m.Files[key] = hash
-		mu.Unlock()
+		// always write
 	}
 
-	return os.WriteFile(fileName, result, 0640)
+	if err := os.WriteFile(fileName, result, 0640); err != nil {
+		return err
+	}
+
+	mu.Lock()
+	m.Files[key] = hash
+	mu.Unlock()
+	return nil
 }
 
 func (g *Generator) pushQueryStructMeta(meta *generate.QueryStructMeta) (*genInfo, error) {

--- a/generator.go
+++ b/generator.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 
 	"golang.org/x/tools/go/packages"
@@ -306,6 +307,13 @@ func (g *Generator) generateQueryFile() (err error) {
 		return fmt.Errorf("make dir outpath(%s) fail: %s", g.OutPath, err)
 	}
 
+	manifest, manifestPath, err := loadManifest(g.OutPath)
+	if err != nil {
+		return err
+	}
+	manifest.Mode = uint(g.Mode)
+	var manifestMu sync.Mutex
+
 	errChan := make(chan error)
 	pool := pools.NewPool(concurrent)
 	// generate query code for all struct
@@ -313,13 +321,13 @@ func (g *Generator) generateQueryFile() (err error) {
 		pool.Wait()
 		go func(info *genInfo) {
 			defer pool.Done()
-			err := g.generateSingleQueryFile(info)
+			err := g.generateSingleQueryFile(info, manifest, &manifestMu)
 			if err != nil {
 				errChan <- err
 			}
 
 			if g.WithUnitTest {
-				err = g.generateQueryUnitTestFile(info)
+				err = g.generateQueryUnitTestFile(info, manifest, &manifestMu)
 				if err != nil { // do not panic
 					g.db.Logger.Error(context.Background(), "generate unit test fail: %s", err)
 				}
@@ -332,6 +340,11 @@ func (g *Generator) generateQueryFile() (err error) {
 	case <-pool.AsyncWaitAll():
 	}
 
+	mergedTables, dataForGenGo := g.buildMergedQueryData(manifest)
+	manifest.Tables = mergedTables
+	genForRoot := *g
+	genForRoot.Data = dataForGenGo
+
 	// generate query file
 	var buf bytes.Buffer
 	err = render(tmpl.Header, &buf, map[string]interface{}{
@@ -343,17 +356,17 @@ func (g *Generator) generateQueryFile() (err error) {
 	}
 
 	if g.judgeMode(WithDefaultQuery) {
-		err = render(tmpl.DefaultQuery, &buf, g)
+		err = render(tmpl.DefaultQuery, &buf, &genForRoot)
 		if err != nil {
 			return err
 		}
 	}
-	err = render(tmpl.QueryMethod, &buf, g)
+	err = render(tmpl.QueryMethod, &buf, &genForRoot)
 	if err != nil {
 		return err
 	}
 
-	err = g.output(g.OutFile, buf.Bytes())
+	err = g.outputWithManifest(g.OutFile, buf.Bytes(), manifest, filepath.Base(g.OutFile), &manifestMu)
 	if err != nil {
 		return err
 	}
@@ -375,13 +388,13 @@ func (g *Generator) generateQueryFile() (err error) {
 		if err != nil {
 			return err
 		}
-		err = render(tmpl.QueryMethodTest, &buf, g)
+		err = render(tmpl.QueryMethodTest, &buf, &genForRoot)
 		if err != nil {
 			g.db.Logger.Error(context.Background(), "generate query unit test fail: %s", err)
 			return nil
 		}
 		fileName := strings.TrimSuffix(g.OutFile, ".go") + "_test.go"
-		err = g.output(fileName, buf.Bytes())
+		err = g.outputWithManifest(fileName, buf.Bytes(), manifest, filepath.Base(fileName), &manifestMu)
 		if err != nil {
 			g.db.Logger.Error(context.Background(), "generate query unit test fail: %s", err)
 			return nil
@@ -389,11 +402,64 @@ func (g *Generator) generateQueryFile() (err error) {
 		g.info("generate unit test file: " + fileName)
 	}
 
+	if err := saveManifest(manifestPath, manifest); err != nil {
+		return err
+	}
 	return nil
 }
 
+func (g *Generator) buildMergedQueryData(manifest *genManifest) (map[string]genManifestTable, map[string]*genInfo) {
+	currentTables := make(map[string]genManifestTable, len(g.Data))
+	for _, d := range g.Data {
+		currentTables[d.ModelStructName] = genManifestTable{
+			ModelStructName: d.ModelStructName,
+			QueryStructName: d.QueryStructName,
+			FileName:        d.FileName,
+		}
+	}
+
+	mergedTables := currentTables
+	if g.MergeQuery {
+		mergedTables = make(map[string]genManifestTable, len(manifest.Tables)+len(currentTables))
+		for k, v := range manifest.Tables {
+			mergedTables[k] = v
+		}
+		for k, v := range currentTables {
+			mergedTables[k] = v
+		}
+		for k, v := range mergedTables {
+			if _, err := os.Stat(filepath.Join(g.OutPath, v.FileName+".gen.go")); err != nil {
+				if _, ok := currentTables[k]; !ok {
+					delete(mergedTables, k)
+				}
+			}
+		}
+	}
+
+	dataForGenGo := g.Data
+	if g.MergeQuery {
+		dataForGenGo = make(map[string]*genInfo, len(mergedTables))
+		for k, v := range g.Data {
+			dataForGenGo[k] = v
+		}
+		for k, v := range mergedTables {
+			if _, ok := dataForGenGo[k]; ok {
+				continue
+			}
+			meta := (&generate.QueryStructMeta{
+				ModelStructName: v.ModelStructName,
+				QueryStructName: v.QueryStructName,
+				FileName:        v.FileName,
+			}).IfaceMode(g.judgeMode(WithQueryInterface) || g.judgeMode(WithGeneric)).GenericMode(g.judgeMode(WithGeneric))
+			dataForGenGo[k] = &genInfo{QueryStructMeta: meta}
+		}
+	}
+
+	return mergedTables, dataForGenGo
+}
+
 // generateSingleQueryFile generate query code and save to file
-func (g *Generator) generateSingleQueryFile(data *genInfo) (err error) {
+func (g *Generator) generateSingleQueryFile(data *genInfo, m *genManifest, mu *sync.Mutex) (err error) {
 	var buf bytes.Buffer
 
 	structPkgPath := data.StructInfo.PkgPath
@@ -456,11 +522,12 @@ func (g *Generator) generateSingleQueryFile(data *genInfo) (err error) {
 	}
 
 	defer g.info(fmt.Sprintf("generate query file: %s%s%s.gen.go", g.OutPath, string(os.PathSeparator), data.FileName))
-	return g.output(fmt.Sprintf("%s%s%s.gen.go", g.OutPath, string(os.PathSeparator), data.FileName), buf.Bytes())
+	fileName := fmt.Sprintf("%s%s%s.gen.go", g.OutPath, string(os.PathSeparator), data.FileName)
+	return g.outputWithManifest(fileName, buf.Bytes(), m, filepath.Base(fileName), mu)
 }
 
 // generateQueryUnitTestFile generate unit test file for query
-func (g *Generator) generateQueryUnitTestFile(data *genInfo) (err error) {
+func (g *Generator) generateQueryUnitTestFile(data *genInfo, m *genManifest, mu *sync.Mutex) (err error) {
 	var buf bytes.Buffer
 
 	structPkgPath := data.StructInfo.PkgPath
@@ -496,7 +563,8 @@ func (g *Generator) generateQueryUnitTestFile(data *genInfo) (err error) {
 	}
 
 	defer g.info(fmt.Sprintf("generate unit test file: %s%s%s.gen_test.go", g.OutPath, string(os.PathSeparator), data.FileName))
-	return g.output(fmt.Sprintf("%s%s%s.gen_test.go", g.OutPath, string(os.PathSeparator), data.FileName), buf.Bytes())
+	fileName := fmt.Sprintf("%s%s%s.gen_test.go", g.OutPath, string(os.PathSeparator), data.FileName)
+	return g.outputWithManifest(fileName, buf.Bytes(), m, filepath.Base(fileName), mu)
 }
 
 // generateModelFile generate model structures and save to file
@@ -513,6 +581,13 @@ func (g *Generator) generateModelFile() error {
 	if err = os.MkdirAll(modelOutPath, os.ModePerm); err != nil {
 		return fmt.Errorf("create model pkg path(%s) fail: %s", modelOutPath, err)
 	}
+
+	manifest, manifestPath, err := loadManifest(modelOutPath)
+	if err != nil {
+		return err
+	}
+	manifest.Mode = uint(g.Mode)
+	var manifestMu sync.Mutex
 
 	errChan := make(chan error)
 	pool := pools.NewPool(concurrent)
@@ -540,7 +615,7 @@ func (g *Generator) generateModelFile() error {
 			}
 
 			modelFile := modelOutPath + data.FileName + ".gen.go"
-			err = g.output(modelFile, buf.Bytes())
+			err = g.outputWithManifest(modelFile, buf.Bytes(), manifest, filepath.Base(modelFile), &manifestMu)
 			if err != nil {
 				errChan <- err
 				return
@@ -553,6 +628,9 @@ func (g *Generator) generateModelFile() error {
 	case err = <-errChan:
 		return err
 	case <-pool.AsyncWaitAll():
+		if err := saveManifest(manifestPath, manifest); err != nil {
+			return err
+		}
 		g.fillModelPkgPath(modelOutPath)
 	}
 	return nil
@@ -586,25 +664,60 @@ func (g *Generator) fillModelPkgPath(filePath string) {
 	g.Config.modelPkgPath = pkgs[0].PkgPath
 }
 
+func (g *Generator) format(fileName string, content []byte) ([]byte, error) {
+	result, err := imports.Process(fileName, content, nil)
+	if err == nil {
+		return result, nil
+	}
+
+	lines := strings.Split(string(content), "\n")
+	errLine, _ := strconv.Atoi(strings.Split(err.Error(), ":")[1])
+	startLine, endLine := errLine-5, errLine+5
+	fmt.Println("Format fail:", errLine, err)
+	if startLine < 0 {
+		startLine = 0
+	}
+	if endLine > len(lines)-1 {
+		endLine = len(lines) - 1
+	}
+	for i := startLine; i <= endLine; i++ {
+		fmt.Println(i, lines[i])
+	}
+	return nil, fmt.Errorf("cannot format file: %w", err)
+}
+
 // output format and output
 func (g *Generator) output(fileName string, content []byte) error {
-	result, err := imports.Process(fileName, content, nil)
+	result, err := g.format(fileName, content)
 	if err != nil {
-		lines := strings.Split(string(content), "\n")
-		errLine, _ := strconv.Atoi(strings.Split(err.Error(), ":")[1])
-		startLine, endLine := errLine-5, errLine+5
-		fmt.Println("Format fail:", errLine, err)
-		if startLine < 0 {
-			startLine = 0
-		}
-		if endLine > len(lines)-1 {
-			endLine = len(lines) - 1
-		}
-		for i := startLine; i <= endLine; i++ {
-			fmt.Println(i, lines[i])
-		}
-		return fmt.Errorf("cannot format file: %w", err)
+		return err
 	}
+	return os.WriteFile(fileName, result, 0640)
+}
+
+func (g *Generator) outputWithManifest(fileName string, content []byte, m *genManifest, key string, mu *sync.Mutex) error {
+	result, err := g.format(fileName, content)
+	if err != nil {
+		return err
+	}
+
+	hash := sha256Hex(result)
+	if g.Incremental {
+		mu.Lock()
+		old := m.Files[key]
+		m.Files[key] = hash
+		mu.Unlock()
+		if old == hash {
+			if _, err := os.Stat(fileName); err == nil {
+				return nil
+			}
+		}
+	} else {
+		mu.Lock()
+		m.Files[key] = hash
+		mu.Unlock()
+	}
+
 	return os.WriteFile(fileName, result, 0640)
 }
 

--- a/generator_incremental_test.go
+++ b/generator_incremental_test.go
@@ -1,0 +1,84 @@
+package gen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"gorm.io/gen/internal/generate"
+)
+
+func TestOutputWithManifest_IncrementalSkipDoesNotOverwrite(t *testing.T) {
+	tmp := t.TempDir()
+	g := NewGenerator(Config{OutPath: tmp})
+	g.Incremental = true
+
+	m := &genManifest{Version: 1, Files: map[string]string{}}
+	var mu sync.Mutex
+
+	fileName := filepath.Join(tmp, "x.go")
+	content := []byte("package p\n\nfunc A() {}\n")
+
+	if err := g.outputWithManifest(fileName, content, m, filepath.Base(fileName), &mu); err != nil {
+		t.Fatalf("first output: %v", err)
+	}
+
+	if err := os.WriteFile(fileName, []byte("package p\n\nfunc B() {}\n"), 0640); err != nil {
+		t.Fatalf("tamper file: %v", err)
+	}
+
+	if err := g.outputWithManifest(fileName, content, m, filepath.Base(fileName), &mu); err != nil {
+		t.Fatalf("second output: %v", err)
+	}
+
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !strings.Contains(string(b), "func B") {
+		t.Fatalf("expected file to keep tampered content, got:\n%s", string(b))
+	}
+}
+
+func TestBuildMergedQueryData_MergeKeepsPreviousTables(t *testing.T) {
+	tmp := t.TempDir()
+	g := NewGenerator(Config{OutPath: tmp})
+	g.MergeQuery = true
+
+	g.Data = map[string]*genInfo{
+		"UserB": {QueryStructMeta: &generate.QueryStructMeta{ModelStructName: "UserB", QueryStructName: "userB", FileName: "user_b"}},
+	}
+
+	if err := os.WriteFile(filepath.Join(tmp, "user_a.gen.go"), []byte("package query\n"), 0640); err != nil {
+		t.Fatalf("write user_a.gen.go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "user_b.gen.go"), []byte("package query\n"), 0640); err != nil {
+		t.Fatalf("write user_b.gen.go: %v", err)
+	}
+
+	manifest := &genManifest{
+		Version: 1,
+		Tables: map[string]genManifestTable{
+			"UserA": {ModelStructName: "UserA", QueryStructName: "userA", FileName: "user_a"},
+		},
+		Files: map[string]string{},
+	}
+
+	mergedTables, dataForGenGo := g.buildMergedQueryData(manifest)
+
+	if _, ok := mergedTables["UserA"]; !ok {
+		t.Fatalf("expected merged tables to contain UserA")
+	}
+	if _, ok := mergedTables["UserB"]; !ok {
+		t.Fatalf("expected merged tables to contain UserB")
+	}
+	if _, ok := dataForGenGo["UserA"]; !ok {
+		t.Fatalf("expected merged data to contain placeholder UserA")
+	}
+	if _, ok := dataForGenGo["UserB"]; !ok {
+		t.Fatalf("expected merged data to contain current UserB")
+	}
+}
+

--- a/manifest.go
+++ b/manifest.go
@@ -1,0 +1,64 @@
+package gen
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const manifestFileName = ".genmanifest.json"
+
+type genManifest struct {
+	Version int `json:"version"`
+	Mode    uint `json:"mode"`
+	Tables  map[string]genManifestTable `json:"tables,omitempty"`
+	Files   map[string]string          `json:"files,omitempty"`
+}
+
+type genManifestTable struct {
+	ModelStructName string `json:"model_struct_name"`
+	QueryStructName string `json:"query_struct_name"`
+	FileName        string `json:"file_name"`
+}
+
+func loadManifest(dir string) (*genManifest, string, error) {
+	path := filepath.Join(dir, manifestFileName)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &genManifest{Version: 1, Tables: map[string]genManifestTable{}, Files: map[string]string{}}, path, nil
+		}
+		return nil, "", err
+	}
+	var m genManifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, "", err
+	}
+	if m.Version == 0 {
+		m.Version = 1
+	}
+	if m.Tables == nil {
+		m.Tables = map[string]genManifestTable{}
+	}
+	if m.Files == nil {
+		m.Files = map[string]string{}
+	}
+	return &m, path, nil
+}
+
+func saveManifest(path string, m *genManifest) error {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(path, b, 0640)
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
Add incremental generation support to reduce noisy diffs in large repos.

Key changes:
- Config.Incremental: writes a .genmanifest.json per output dir and skips rewriting files when the formatted output hash is unchanged
- Config.MergeQuery: when generating subsets, keeps previously generated query entries so gen.go aggregates A+B across runs
- Model generation also respects Incremental (no merge; just skip unchanged writes)

Implementation details:
- Manifest file: .genmanifest.json stored under OutPath (query) and model output dir
- Hash is computed from goimports-formatted content to avoid import-order churn

Tests:
- Added unit tests for incremental skip and merge behavior