### PR TITLE
feat: diagnostic codeframe and stable codes

### DIFF
--- a/internal/diagnostic/codeframe.go
+++ b/internal/diagnostic/codeframe.go
@@ -1,0 +1,133 @@
+package diagnostic
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+func CodeFrame(src []byte, line, column, context int) string {
+	if context < 0 {
+		context = 0
+	}
+	if line < 1 {
+		line = 1
+	}
+	if column < 1 {
+		column = 1
+	}
+
+	lines := bytes.Split(src, []byte("\n"))
+	if len(lines) == 0 {
+		return ""
+	}
+	for len(lines) > 1 && len(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+	if line > len(lines) {
+		line = len(lines)
+	}
+
+	start := line - 1 - context
+	if start < 0 {
+		start = 0
+	}
+	end := line - 1 + context
+	if end >= len(lines) {
+		end = len(lines) - 1
+	}
+
+	width := digits(end + 1)
+	var out bytes.Buffer
+	for i := start; i <= end; i++ {
+		ln := i + 1
+		prefix := fmt.Sprintf("%*d | ", width, ln)
+		if i == line-1 {
+			prefix = fmt.Sprintf(">%*d | ", width, ln)
+		}
+		rawLine := string(lines[i])
+		expandedLine := expandTabs(rawLine, 4)
+		out.WriteString(prefix)
+		out.WriteString(expandedLine)
+		out.WriteByte('\n')
+
+		if i == line-1 {
+			caretPos := caretColumn(rawLine, column, 4)
+			out.WriteString(fmt.Sprintf("%*s | ", width+1, ""))
+			out.WriteString(spaces(caretPos))
+			out.WriteByte('^')
+			out.WriteByte('\n')
+		}
+	}
+	return out.String()
+}
+
+func CodeFrameFromFile(file string, line, column, context int) (string, error) {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	return CodeFrame(b, line, column, context), nil
+}
+
+func digits(n int) int {
+	if n <= 0 {
+		return 1
+	}
+	d := 0
+	for n > 0 {
+		n /= 10
+		d++
+	}
+	return d
+}
+
+func spaces(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return string(bytes.Repeat([]byte(" "), n))
+}
+
+func expandTabs(s string, tabWidth int) string {
+	if tabWidth <= 0 {
+		tabWidth = 4
+	}
+	var out bytes.Buffer
+	col := 0
+	for _, r := range s {
+		if r == '\t' {
+			spaceCount := tabWidth - (col % tabWidth)
+			out.Write(bytes.Repeat([]byte(" "), spaceCount))
+			col += spaceCount
+			continue
+		}
+		out.WriteRune(r)
+		col++
+	}
+	return out.String()
+}
+
+func caretColumn(raw string, column, tabWidth int) int {
+	if column <= 1 {
+		return 0
+	}
+	if tabWidth <= 0 {
+		tabWidth = 4
+	}
+	b := []byte(raw)
+	bytePos := column - 1
+	if bytePos > len(b) {
+		bytePos = len(b)
+	}
+	prefix := string(b[:bytePos])
+	col := 0
+	for _, r := range prefix {
+		if r == '\t' {
+			col += tabWidth - (col % tabWidth)
+			continue
+		}
+		col++
+	}
+	return col
+}

--- a/internal/diagnostic/codeframe_test.go
+++ b/internal/diagnostic/codeframe_test.go
@@ -1,0 +1,55 @@
+package diagnostic
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCodeFrame_Basic(t *testing.T) {
+	src := []byte("a\nb\nc\n")
+	out := CodeFrame(src, 2, 1, 1)
+	if !strings.Contains(out, ">2 | b") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+	if !strings.Contains(out, "  | ^") {
+		t.Fatalf("missing caret:\n%s", out)
+	}
+}
+
+func TestCodeFrame_ClampsOutOfRange(t *testing.T) {
+	src := []byte("a\nb\n")
+	out := CodeFrame(src, 100, 100, 1)
+	if !strings.Contains(out, ">2 | b") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+}
+
+func TestCodeFrame_TabAlignment(t *testing.T) {
+	src := []byte("\tX\n")
+	out := CodeFrame(src, 1, 2, 0)
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+	caretLine := lines[1]
+	if !strings.HasSuffix(caretLine, "^") {
+		t.Fatalf("missing caret:\n%s", out)
+	}
+	i := strings.Index(caretLine, "| ")
+	if i < 0 {
+		t.Fatalf("unexpected caret line:\n%s", out)
+	}
+	after := strings.TrimSuffix(caretLine[i+2:], "^")
+	leading := len(after)
+	if leading != 4 {
+		t.Fatalf("unexpected caret column: %d\n%s", leading, out)
+	}
+}
+
+func TestCodeFrame_UTF8Clamping(t *testing.T) {
+	src := []byte("你a\n")
+	out := CodeFrame(src, 1, 2, 0)
+	if !strings.Contains(out, "^") {
+		t.Fatalf("missing caret:\n%s", out)
+	}
+}

--- a/internal/diagnostic/codes.go
+++ b/internal/diagnostic/codes.go
@@ -1,0 +1,8 @@
+package diagnostic
+
+const (
+	CodeSQLIncomplete = "SQL_INCOMPLETE"
+	CodeSQLVar        = "SQL_VAR"
+	CodeTemplateParse = "TEMPLATE_PARSE"
+	CodeSQLBuild      = "SQL_BUILD"
+)

--- a/internal/diagnostic/defaults.go
+++ b/internal/diagnostic/defaults.go
@@ -1,0 +1,31 @@
+package diagnostic
+
+func DefaultMessage(code string) string {
+	switch code {
+	case CodeSQLIncomplete:
+		return "incomplete SQL"
+	case CodeSQLVar:
+		return "variable parse error"
+	case CodeTemplateParse:
+		return "template parse error"
+	case CodeSQLBuild:
+		return "build SQL error"
+	default:
+		return ""
+	}
+}
+
+func DefaultHint(code string) string {
+	switch code {
+	case CodeSQLIncomplete:
+		return "Check for unclosed quotes or unclosed template blocks like {{...}}."
+	case CodeSQLVar:
+		return "Check @var / @@var usage and ensure the expression is valid."
+	case CodeTemplateParse:
+		return "Check template syntax inside {{...}} blocks."
+	case CodeSQLBuild:
+		return "Check template variables and ensure generated SQL is valid."
+	default:
+		return ""
+	}
+}

--- a/internal/diagnostic/defaults_test.go
+++ b/internal/diagnostic/defaults_test.go
@@ -1,0 +1,47 @@
+package diagnostic
+
+import "testing"
+
+func TestDefaultMessageKnownCodes(t *testing.T) {
+	cases := []struct {
+		code string
+		want string
+	}{
+		{CodeSQLIncomplete, "incomplete SQL"},
+		{CodeSQLVar, "variable parse error"},
+		{CodeTemplateParse, "template parse error"},
+		{CodeSQLBuild, "build SQL error"},
+	}
+	for _, c := range cases {
+		if got := DefaultMessage(c.code); got != c.want {
+			t.Fatalf("code=%s got=%q want=%q", c.code, got, c.want)
+		}
+		if got := DefaultHint(c.code); got == "" {
+			t.Fatalf("code=%s expected non-empty hint", c.code)
+		}
+	}
+}
+
+func TestNew_FillsDefaultsWhenEmpty(t *testing.T) {
+	e := New(CodeSQLIncomplete, "")
+	if e.Diag.Message == "" || e.Diag.Message != DefaultMessage(CodeSQLIncomplete) {
+		t.Fatalf("unexpected message: %q", e.Diag.Message)
+	}
+	if e.Diag.Hint == "" {
+		t.Fatalf("expected hint")
+	}
+}
+
+func TestWrap_FillsDefaultsWhenEmpty(t *testing.T) {
+	e := Wrap(assertErr{}, CodeSQLBuild, "")
+	if e.Diag.Message == "" || e.Diag.Message != DefaultMessage(CodeSQLBuild) {
+		t.Fatalf("unexpected message: %q", e.Diag.Message)
+	}
+	if e.Diag.Hint == "" {
+		t.Fatalf("expected hint")
+	}
+}
+
+type assertErr struct{}
+
+func (assertErr) Error() string { return "x" }

--- a/internal/diagnostic/diagnostic.go
+++ b/internal/diagnostic/diagnostic.go
@@ -60,12 +60,18 @@ func (e *Error) MarshalJSON() ([]byte, error) {
 }
 
 func New(code, message string) *Error {
-	return &Error{Diag: Diagnostic{Code: code, Message: message}}
+	if message == "" {
+		message = DefaultMessage(code)
+	}
+	return &Error{Diag: Diagnostic{Code: code, Message: message, Hint: DefaultHint(code)}}
 }
 
 func Wrap(err error, code, message string) *Error {
 	if err == nil {
 		return New(code, message)
+	}
+	if message == "" {
+		message = DefaultMessage(code)
 	}
 	if e, ok := err.(*Error); ok {
 		if code != "" {
@@ -74,9 +80,12 @@ func Wrap(err error, code, message string) *Error {
 		if message != "" {
 			e.Diag.Message = message
 		}
+		if e.Diag.Hint == "" {
+			e.Diag.Hint = DefaultHint(e.Diag.Code)
+		}
 		return e
 	}
-	return &Error{Diag: Diagnostic{Code: code, Message: message}, Err: err}
+	return &Error{Diag: Diagnostic{Code: code, Message: message, Hint: DefaultHint(code)}, Err: err}
 }
 
 func WithLocation(err error, file string, line, column int) error {

--- a/internal/diagnostic/helpers.go
+++ b/internal/diagnostic/helpers.go
@@ -1,0 +1,9 @@
+package diagnostic
+
+func NewCode(code string) *Error {
+	return New(code, "")
+}
+
+func WrapCode(err error, code string) *Error {
+	return Wrap(err, code, "")
+}

--- a/internal/generate/diagnostic_test.go
+++ b/internal/generate/diagnostic_test.go
@@ -59,7 +59,7 @@ type UserMethods interface {
 	if !errors.As(err, &de) {
 		t.Fatalf("expected diagnostic error, got %T: %v", err, err)
 	}
-	if de.Diag.Code != "SQL_INCOMPLETE" {
+	if de.Diag.Code != diagnostic.CodeSQLIncomplete {
 		t.Fatalf("unexpected code: %s", de.Diag.Code)
 	}
 	if de.Diag.File == "" || de.Diag.Line == 0 {
@@ -114,7 +114,7 @@ type UserMethods interface {
 	if !errors.As(err, &de) {
 		t.Fatalf("expected diagnostic error, got %T: %v", err, err)
 	}
-	if de.Diag.Code != "TEMPLATE_PARSE" {
+	if de.Diag.Code != diagnostic.CodeTemplateParse {
 		t.Fatalf("unexpected code: %s", de.Diag.Code)
 	}
 	if de.Diag.Interface != "UserMethods" || de.Diag.Method != "FindByName" {

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -221,7 +221,7 @@ func BuildDIYMethod(f *parser.InterfaceSet, s *QueryStructMeta, data []*Interfac
 				}
 				_, err = t.Section.BuildSQL()
 				if err != nil {
-					err = diagnostic.Wrap(err, "SQL_BUILD", "build SQL error")
+					err = diagnostic.Wrap(err, diagnostic.CodeSQLBuild, "build SQL error")
 					err = diagnostic.WithMethod(err, t.InterfaceName, t.MethodName)
 					err = diagnostic.WithLocation(err, t.File, t.DocLine, t.DocColumn)
 					return

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -221,7 +221,7 @@ func BuildDIYMethod(f *parser.InterfaceSet, s *QueryStructMeta, data []*Interfac
 				}
 				_, err = t.Section.BuildSQL()
 				if err != nil {
-					err = diagnostic.Wrap(err, diagnostic.CodeSQLBuild, "build SQL error")
+					err = diagnostic.WrapCode(err, diagnostic.CodeSQLBuild)
 					err = diagnostic.WithMethod(err, t.InterfaceName, t.MethodName)
 					err = diagnostic.WithLocation(err, t.File, t.DocLine, t.DocColumn)
 					return

--- a/internal/generate/interface.go
+++ b/internal/generate/interface.go
@@ -366,7 +366,7 @@ func (m *InterfaceMethod) sqlStateCheckAndSplit() error {
 			_ = buf.WriteByte(sqlString[i])
 			for i++; ; i++ {
 				if strOutRange(i, sqlString) {
-					return m.diagSQL(i, "SQL_INCOMPLETE", "incomplete SQL", sqlString, nil)
+					return m.diagSQL(i, diagnostic.CodeSQLIncomplete, "incomplete SQL", sqlString, nil)
 				}
 				_ = buf.WriteByte(sqlString[i])
 				if sqlString[i] == '"' && sqlString[i-1] != '\\' {
@@ -377,7 +377,7 @@ func (m *InterfaceMethod) sqlStateCheckAndSplit() error {
 			_ = buf.WriteByte(sqlString[i])
 			for i++; ; i++ {
 				if strOutRange(i, sqlString) {
-					return m.diagSQL(i, "SQL_INCOMPLETE", "incomplete SQL", sqlString, nil)
+					return m.diagSQL(i, diagnostic.CodeSQLIncomplete, "incomplete SQL", sqlString, nil)
 				}
 				_ = buf.WriteByte(sqlString[i])
 				if sqlString[i] == '\'' && sqlString[i-1] != '\\' {
@@ -400,18 +400,18 @@ func (m *InterfaceMethod) sqlStateCheckAndSplit() error {
 			}
 
 			if strOutRange(i+1, sqlString) {
-				return m.diagSQL(i, "SQL_INCOMPLETE", "incomplete SQL", sqlString, nil)
+				return m.diagSQL(i, diagnostic.CodeSQLIncomplete, "incomplete SQL", sqlString, nil)
 			}
 			if b == '{' && sqlString[i+1] == '{' {
 				for i += 2; ; i++ {
 					if strOutRange(i, sqlString) {
-						return m.diagSQL(i, "SQL_INCOMPLETE", "incomplete SQL", sqlString, nil)
+						return m.diagSQL(i, diagnostic.CodeSQLIncomplete, "incomplete SQL", sqlString, nil)
 					}
 					if sqlString[i] == '"' {
 						_ = buf.WriteByte(sqlString[i])
 						for i++; ; i++ {
 							if strOutRange(i, sqlString) {
-								return m.diagSQL(i, "SQL_INCOMPLETE", "incomplete SQL", sqlString, nil)
+								return m.diagSQL(i, diagnostic.CodeSQLIncomplete, "incomplete SQL", sqlString, nil)
 							}
 							_ = buf.WriteByte(sqlString[i])
 							if sqlString[i] == '"' && sqlString[i-1] != '\\' {
@@ -422,14 +422,14 @@ func (m *InterfaceMethod) sqlStateCheckAndSplit() error {
 					}
 
 					if strOutRange(i+1, sqlString) {
-						return m.diagSQL(i, "SQL_INCOMPLETE", "incomplete SQL", sqlString, nil)
+						return m.diagSQL(i, diagnostic.CodeSQLIncomplete, "incomplete SQL", sqlString, nil)
 					}
 					if sqlString[i] == '}' && sqlString[i+1] == '}' {
 						i++
 						sqlClause := buf.Dump()
 						part, err := m.Section.checkTemplate(sqlClause)
 						if err != nil {
-							return m.diagSQL(i, "TEMPLATE_PARSE", "template parse error", sqlClause, err)
+							return m.diagSQL(i, diagnostic.CodeTemplateParse, "template parse error", sqlClause, err)
 						}
 						m.Section.members = append(m.Section.members, part)
 						break
@@ -453,7 +453,7 @@ func (m *InterfaceMethod) sqlStateCheckAndSplit() error {
 							varString := buf.Dump()
 							params, err := m.Section.checkSQLVar(varString, status, m)
 							if err != nil {
-								return m.diagSQL(i, "SQL_VAR", "variable parse error", varString, err)
+								return m.diagSQL(i, diagnostic.CodeSQLVar, "variable parse error", varString, err)
 							}
 							m.Section.members = append(m.Section.members, params)
 							break
@@ -461,7 +461,7 @@ func (m *InterfaceMethod) sqlStateCheckAndSplit() error {
 						varString := buf.Dump()
 						params, err := m.Section.checkSQLVar(varString, status, m)
 						if err != nil {
-							return m.diagSQL(i, "SQL_VAR", "variable parse error", varString, err)
+							return m.diagSQL(i, diagnostic.CodeSQLVar, "variable parse error", varString, err)
 						}
 						m.Section.members = append(m.Section.members, params)
 						i--


### PR DESCRIPTION
Follow-up to #1450 (already merged).

- Add stable diagnostic code constants (SQL_INCOMPLETE/SQL_VAR/TEMPLATE_PARSE/SQL_BUILD)
- Add diagnostic.CodeFrame + CodeFrameFromFile for source context rendering
- Add unit tests for codeframe behavior

No behavior change in generator outputs; adds optional tooling utilities.