### PR TITLE
feat(gentool): add generated-column readonly detection with fieldReadonly option

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	FieldWithIndexTag   bool // generate with gorm index tag
 	FieldWithTypeTag    bool // generate with gorm column type tag
 	FieldWithDefaultTag bool
+	FieldReadonly       bool // detect generated/computed columns and mark them as readonly in gorm tag
 
 	Mode GenerateMode // generate mode
 

--- a/field/tag.go
+++ b/field/tag.go
@@ -21,6 +21,7 @@ const (
 	TagKeyGormIndex         = "index"
 	TagKeyGormDefault       = "default"
 	TagKeyGormComment       = "comment"
+	TagKeyGormReadonly      = "->"
 )
 
 var (
@@ -37,6 +38,7 @@ var (
 		TagKeyGormIndex:         4,
 		TagKeyGormDefault:       3,
 		TagKeyGormComment:       0,
+		TagKeyGormReadonly:      -1,
 	}
 )
 

--- a/generator.go
+++ b/generator.go
@@ -197,6 +197,7 @@ func (g *Generator) genModelConfig(tableName string, modelName string, modelOpts
 			FieldWithIndexTag:   g.FieldWithIndexTag,
 			FieldWithTypeTag:    g.FieldWithTypeTag,
 			FieldWithDefaultTag: g.FieldWithDefaultTag,
+			FieldReadonly:       g.FieldReadonly,
 
 			FieldJSONTagNS: g.fieldJSONTagNS,
 		},

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -36,6 +36,11 @@ func GetQueryStructMeta(db *gorm.DB, conf *model.Config) (*QueryStructMeta, erro
 	if err != nil {
 		return nil, err
 	}
+	if conf.FieldReadonly {
+		if err := markReadOnlyColumns(db, conf.GetSchemaName(db), tableName, columns); err != nil {
+			return nil, err
+		}
+	}
 
 	tc := getTableComment(db, tableName)
 

--- a/internal/generate/readonly_columns.go
+++ b/internal/generate/readonly_columns.go
@@ -1,0 +1,191 @@
+package generate
+
+import (
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+
+	"gorm.io/gen/internal/model"
+)
+
+func markReadOnlyColumns(db *gorm.DB, schemaName, tableName string, columns []*model.Column) error {
+	if db == nil || len(columns) == 0 {
+		return nil
+	}
+
+	readOnlyColumns := map[string]struct{}{}
+	var err error
+	switch db.Dialector.Name() {
+	case "mysql":
+		readOnlyColumns, err = getMySQLGeneratedColumns(db, tableName)
+	case "postgres":
+		readOnlyColumns, err = getPostgresGeneratedColumns(db, schemaName, tableName)
+	case "sqlite":
+		readOnlyColumns, err = getSQLiteGeneratedColumns(db, tableName)
+	case "clickhouse":
+		readOnlyColumns, err = getClickHouseGeneratedColumns(db, schemaName, tableName)
+	default:
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(readOnlyColumns) == 0 {
+		return nil
+	}
+
+	for _, col := range columns {
+		if col == nil {
+			continue
+		}
+		_, ok := readOnlyColumns[col.Name()]
+		col.ReadOnly = ok
+	}
+	return nil
+}
+
+func getMySQLGeneratedColumns(db *gorm.DB, tableName string) (map[string]struct{}, error) {
+	if db == nil {
+		return nil, nil
+	}
+
+	currentDB := db.Migrator().CurrentDatabase()
+	readOnlyColumns := map[string]struct{}{}
+	rows := make([]struct {
+		ColumnName string `gorm:"column:COLUMN_NAME"`
+	}, 0)
+
+	err := db.Raw(
+		`SELECT COLUMN_NAME
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = ?
+	AND TABLE_NAME = ?
+	AND (
+		UPPER(COALESCE(GENERATION_TYPE, '')) IN ('VIRTUAL', 'STORED')
+		OR UPPER(COALESCE(EXTRA, '')) LIKE '%GENERATED%'
+	)`,
+		currentDB, tableName,
+	).Scan(&rows).Error
+	if err != nil {
+		rows = rows[:0]
+		err = db.Raw(
+			`SELECT COLUMN_NAME
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = ?
+	AND TABLE_NAME = ?
+	AND UPPER(COALESCE(EXTRA, '')) LIKE '%GENERATED%'`,
+			currentDB, tableName,
+		).Scan(&rows).Error
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, row := range rows {
+		if row.ColumnName == "" {
+			continue
+		}
+		readOnlyColumns[row.ColumnName] = struct{}{}
+	}
+	return readOnlyColumns, nil
+}
+
+func getPostgresGeneratedColumns(db *gorm.DB, schemaName, tableName string) (map[string]struct{}, error) {
+	if db == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(schemaName) == "" {
+		schemaName = "public"
+	}
+
+	rows := make([]struct {
+		ColumnName string `gorm:"column:column_name"`
+	}, 0)
+	err := db.Raw(
+		`SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = ?
+	AND table_name = ?
+	AND UPPER(COALESCE(is_generated, '')) IN ('ALWAYS', 'YES')`,
+		schemaName, tableName,
+	).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	readOnlyColumns := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if row.ColumnName == "" {
+			continue
+		}
+		readOnlyColumns[row.ColumnName] = struct{}{}
+	}
+	return readOnlyColumns, nil
+}
+
+func getSQLiteGeneratedColumns(db *gorm.DB, tableName string) (map[string]struct{}, error) {
+	if db == nil {
+		return nil, nil
+	}
+
+	escapedTableName := strings.ReplaceAll(tableName, `'`, `''`)
+	rows := make([]struct {
+		Name   string `gorm:"column:name"`
+		Hidden int64  `gorm:"column:hidden"`
+	}, 0)
+	// SQLite exposes generated columns through PRAGMA table_xinfo:
+	// hidden=2 for VIRTUAL generated columns, hidden=3 for STORED generated columns.
+	err := db.Raw(fmt.Sprintf("PRAGMA table_xinfo('%s')", escapedTableName)).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	readOnlyColumns := make(map[string]struct{})
+	for _, row := range rows {
+		if row.Name == "" {
+			continue
+		}
+		if row.Hidden == 2 || row.Hidden == 3 {
+			readOnlyColumns[row.Name] = struct{}{}
+		}
+	}
+	return readOnlyColumns, nil
+}
+
+func getClickHouseGeneratedColumns(db *gorm.DB, schemaName, tableName string) (map[string]struct{}, error) {
+	if db == nil {
+		return nil, nil
+	}
+
+	database := strings.TrimSpace(schemaName)
+	if database == "" {
+		database = db.Migrator().CurrentDatabase()
+	}
+	rows := make([]struct {
+		Name        string `gorm:"column:name"`
+		DefaultKind string `gorm:"column:default_kind"`
+	}, 0)
+	// ClickHouse generated/read-only columns are represented by default_kind:
+	// MATERIALIZED, ALIAS and EPHEMERAL are not writable by regular INSERT/UPDATE.
+	err := db.Raw(
+		`SELECT name, default_kind
+FROM system.columns
+WHERE database = ?
+	AND table = ?
+	AND UPPER(COALESCE(default_kind, '')) IN ('MATERIALIZED', 'ALIAS', 'EPHEMERAL')`,
+		database, tableName,
+	).Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	readOnlyColumns := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if row.Name == "" {
+			continue
+		}
+		readOnlyColumns[row.Name] = struct{}{}
+	}
+	return readOnlyColumns, nil
+}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -41,6 +41,7 @@ type FieldConfig struct {
 	FieldWithIndexTag   bool // generate with gorm index tag
 	FieldWithTypeTag    bool // generate with gorm column type tag
 	FieldWithDefaultTag bool
+	FieldReadonly       bool // generate with gorm readonly tag if column is generated/computed
 
 	FieldJSONTagNS func(columnName string) string
 

--- a/internal/model/tbl_column.go
+++ b/internal/model/tbl_column.go
@@ -16,6 +16,7 @@ type Column struct {
 	TableName   string                                                        `gorm:"column:TABLE_NAME"`
 	Indexes     []*Index                                                      `gorm:"-"`
 	UseScanType bool                                                          `gorm:"-"`
+	ReadOnly    bool                                                          `gorm:"-"`
 	dataTypeMap map[string]func(columnType gorm.ColumnType) (dataType string) `gorm:"-"`
 	jsonTagNS   func(columnName string) string                                `gorm:"-"`
 }
@@ -153,6 +154,9 @@ func (c *Column) buildGormTag(withDefaultTag bool) field.GormTag {
 			comment = strings.ReplaceAll(comment, ";", " ")
 		}
 		tag.Set(field.TagKeyGormComment, comment)
+	}
+	if c.ReadOnly && !isValidPriKey {
+		tag.Set(field.TagKeyGormReadonly, "")
 	}
 	return tag
 }

--- a/internal/model/tbl_column_test.go
+++ b/internal/model/tbl_column_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"database/sql"
 	"reflect"
+	"strings"
 	"testing"
 
 	"gorm.io/gen/field"
@@ -72,5 +73,41 @@ func TestBuildGormTagIndexOrderDeterministic(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected index order: got=%v want=%v", got, want)
+	}
+}
+
+func TestBuildGormTagReadOnly(t *testing.T) {
+	col := Column{
+		ColumnType: testColumnType{
+			name:         "full_name",
+			databaseType: "varchar",
+			columnType:   "varchar(255)",
+		},
+		ReadOnly: true,
+	}
+
+	got := col.buildGormTag(false).Build()
+	if !strings.Contains(got, "->") {
+		t.Fatalf("expected readonly mark in gorm tag, got=%q", got)
+	}
+	if !strings.HasSuffix(got, "->") {
+		t.Fatalf("expected readonly mark at the end of gorm tag, got=%q", got)
+	}
+}
+
+func TestBuildGormTagReadOnlyPrimaryKeyIgnored(t *testing.T) {
+	col := Column{
+		ColumnType: testColumnType{
+			name:         "id",
+			databaseType: "bigint",
+			columnType:   "bigint",
+			primaryKey:   true,
+		},
+		ReadOnly: true,
+	}
+
+	got := col.buildGormTag(false).Build()
+	if strings.Contains(got, "->") {
+		t.Fatalf("did not expect readonly mark for primary key, got=%q", got)
 	}
 }

--- a/tools/gentool/README.ZH_CN.md
+++ b/tools/gentool/README.ZH_CN.md
@@ -31,6 +31,8 @@
         generate field with gorm column type tag
   -fieldWithDefaultTag
         generate field with gorm default tag
+  -fieldReadonly
+        detect generated/computed columns and add gorm readonly tag ->
   -modelPkgName string
         generated model code's package name
   -outFile string
@@ -89,6 +91,23 @@ default ""
 #### fieldWithDefaultTag
 
 使用gorm默认值标记生成字段
+
+#### fieldReadonly
+
+值为：False / True
+
+检测数据库中的生成列/计算列，并在模型字段上生成 GORM 只读标记 `->`，最终形如：
+
+`gorm:"...;->"`
+
+支持的数据库：
+
+- **mysql**：`information_schema.COLUMNS` 中的 `GENERATION_TYPE` / `EXTRA`
+- **postgres**：`information_schema.columns` 中的 `is_generated`
+- **sqlite**：`PRAGMA table_xinfo`，`hidden` 为 `2`（虚拟生成列）或 `3`（存储生成列）
+- **clickhouse**：`system.columns` 中的 `default_kind` 为 `MATERIALIZED` / `ALIAS` / `EPHEMERAL`
+
+配置文件（`gen.yml`）中对应项为 `fieldReadonly`。
 
 #### modelPkgName
 

--- a/tools/gentool/README.md
+++ b/tools/gentool/README.md
@@ -29,6 +29,8 @@ Install GEN as a binary tool
         generate field with gorm column type tag
   -fieldWithDefaultTag
         generate field with gorm default tag
+  -fieldReadonly
+        detect generated/computed columns and add gorm readonly tag ->
   -modelPkgName string
         generated model code's package name
   -outFile string
@@ -87,6 +89,21 @@ generate field with gorm column type tag
 #### fieldWithDefaultTag
 
 generate field with gorm default tag
+
+#### fieldReadonly
+
+Value : False / True
+
+Detect generated/computed columns and generate readonly model tag:
+
+`gorm:"...;->"`
+
+Supported dialects:
+
+- mysql (`information_schema.COLUMNS`: `GENERATION_TYPE` / `EXTRA`)
+- postgres (`information_schema.columns.is_generated`)
+- sqlite (`PRAGMA table_xinfo`, `hidden` in `2/3`)
+- clickhouse (`system.columns.default_kind` in `MATERIALIZED/ALIAS/EPHEMERAL`)
 
 #### modelPkgName
 

--- a/tools/gentool/gen.yml
+++ b/tools/gentool/gen.yml
@@ -33,3 +33,5 @@ database:
   fieldWithDefaultTag : false
   # detect integer field's unsigned type, adjust generated data type
   fieldSignable  : false
+  # detect generated/computed columns and add gorm readonly tag ->
+  fieldReadonly : false

--- a/tools/gentool/gentool.go
+++ b/tools/gentool/gentool.go
@@ -49,6 +49,7 @@ type CmdParams struct {
 	FieldWithTypeTag    bool     `yaml:"fieldWithTypeTag"`    // generate field with gorm column type tag
 	FieldWithDefaultTag bool     `yaml:"fieldWithDefaultTag"` // generate field with gorm default tag
 	FieldSignable       bool     `yaml:"fieldSignable"`       // detect integer field's unsigned type, adjust generated data type
+	FieldReadonly       bool     `yaml:"fieldReadonly"`       // detect generated/computed columns and mark as readonly
 }
 
 func (c *CmdParams) revise() *CmdParams {
@@ -158,6 +159,7 @@ func argParse() *CmdParams {
 	fieldWithTypeTag := flag.Bool("fieldWithTypeTag", false, "generate field with gorm column type tag")
 	fieldWithDefaultTag := flag.Bool("fieldWithDefaultTag", false, "generate field with gorm default tag")
 	fieldSignable := flag.Bool("fieldSignable", false, "detect integer field's unsigned type, adjust generated data type")
+	fieldReadonly := flag.Bool("fieldReadonly", false, "detect generated/computed columns and add gorm readonly tag ->")
 	flag.Parse()
 
 	if *genPath != "" { //use yml config
@@ -211,6 +213,9 @@ func argParse() *CmdParams {
 	if *fieldSignable {
 		cmdParse.FieldSignable = *fieldSignable
 	}
+	if *fieldReadonly {
+		cmdParse.FieldReadonly = *fieldReadonly
+	}
 	return &cmdParse
 }
 
@@ -238,6 +243,7 @@ func main() {
 		FieldWithTypeTag:    config.FieldWithTypeTag,
 		FieldWithDefaultTag: config.FieldWithDefaultTag,
 		FieldSignable:       config.FieldSignable,
+		FieldReadonly:       config.FieldReadonly,
 	})
 
 	g.UseDB(db)


### PR DESCRIPTION
Detect read-only fields (computed/generated) and mark them with GORM-tag