### PR TITLE
Add RelationDepth + DeepRelations controls

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -620,3 +620,15 @@ func getImportPkgPaths(data *genInfo) []string {
 	}
 	return importPkgPaths
 }
+
+// RelationDepth caps how many levels of nested relation fields are generated
+// for query code (1 = direct relations only). The default is unlimited, which
+// matches upstream gorm/gen behavior. (lemmata fork)
+func RelationDepth(depth int) { generate.SetRelationDepth(depth) }
+
+// DeepRelations marks specific root-qualified relation paths (e.g.
+// "OrgAssessment.OrgOngoingAssessment.OrgQuestionnaires") to be generated as
+// typed nested accessors regardless of the RelationDepth cap. Only the listed
+// branches are expanded, so the generated-code cost is limited to exactly those
+// paths. (lemmata fork)
+func DeepRelations(paths ...string) { generate.SetDeepRelations(paths) }

--- a/generator.go
+++ b/generator.go
@@ -626,8 +626,7 @@ func getImportPkgPaths(data *genInfo) []string {
 // matches upstream gorm/gen behavior. (lemmata fork)
 func RelationDepth(depth int) { generate.SetRelationDepth(depth) }
 
-// DeepRelations marks specific root-qualified relation paths (e.g.
-// "OrgAssessment.OrgOngoingAssessment.OrgQuestionnaires") to be generated as
+// DeepRelations marks specific root-qualified relation paths (e.g. "Users.Groups.Permissions") to be generated as
 // typed nested accessors regardless of the RelationDepth cap. Only the listed
 // branches are expanded, so the generated-code cost is limited to exactly those
 // paths. (lemmata fork)

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -216,14 +216,15 @@ func BuildDIYMethod(f *parser.InterfaceSet, s *QueryStructMeta, data []*Interfac
 
 // ParseStructRelationShip parse struct's relationship
 // No one should use it directly in project
-func ParseStructRelationShip(relationship *schema.Relationships) []field.Relation {
+func ParseStructRelationShip(relationship *schema.Relationships, rootName string) []field.Relation {
 	cache := make(map[string]bool)
+	depth := relationDepth()
 	return append(append(append(append(
 		make([]field.Relation, 0, 4),
-		pullRelationShip(cache, relationship.HasOne)...),
-		pullRelationShip(cache, relationship.HasMany)...),
-		pullRelationShip(cache, relationship.BelongsTo)...),
-		pullRelationShip(cache, relationship.Many2Many)...,
+		pullRelationShip(cache, relationship.HasOne, depth, rootName)...),
+		pullRelationShip(cache, relationship.HasMany, depth, rootName)...),
+		pullRelationShip(cache, relationship.BelongsTo, depth, rootName)...),
+		pullRelationShip(cache, relationship.Many2Many, depth, rootName)...,
 	)
 }
 

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -47,7 +47,7 @@ func getFields(db *gorm.DB, conf *model.Config, columns []*model.Column) (fields
 				stmt := gorm.Statement{DB: db}
 				_ = stmt.Parse(m.Relation.Model())
 				if stmt.Schema != nil {
-					m.Relation.AppendChildRelation(ParseStructRelationShip(&stmt.Schema.Relationships)...)
+					m.Relation.AppendChildRelation(ParseStructRelationShip(&stmt.Schema.Relationships, stmt.Schema.Name)...)
 				}
 			}
 			m.Type = strings.ReplaceAll(m.Type, conf.ModelPkg+".", "") // remove modelPkg in field's Type, avoid import error

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -3,7 +3,9 @@ package generate
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"gorm.io/gorm"
@@ -74,7 +76,7 @@ func (b *QueryStructMeta) parseStruct(st interface{}) error {
 		gf.MultilineComment = strings.Contains(gf.ColumnComment, "\n")
 		b.appendOrUpdateField(gf)
 	}
-	for _, r := range ParseStructRelationShip(&stmt.Schema.Relationships) {
+	for _, r := range ParseStructRelationShip(&stmt.Schema.Relationships, stmt.Schema.Name) {
 		r := r
 		b.appendOrUpdateField(&model.Field{Relation: &r})
 	}
@@ -254,15 +256,80 @@ func isStructType(data reflect.Value) bool {
 		(data.Kind() == reflect.Ptr && data.Elem().Kind() == reflect.Struct)
 }
 
-func pullRelationShip(cache map[string]bool, relationships []*schema.Relationship) []field.Relation {
+// Relation-generation controls (lemmata fork).
+//
+// gorm/gen normally expands the full transitive closure of model relations into
+// nested RelationField structs. In a densely-connected schema that is
+// combinatorial and produces millions of lines of generated code. These knobs
+// cap that expansion while still allowing specific paths to stay fully typed.
+var (
+	relationDepthLimit = -1     // <0 => use GEN_RELATION_DEPTH / default
+	deepRelationPaths  []string // root-qualified paths kept typed past the cap
+)
+
+// SetRelationDepth caps how many levels of nested relation fields are generated
+// (1 = direct relations only). Overrides GEN_RELATION_DEPTH.
+func SetRelationDepth(d int) { relationDepthLimit = d }
+
+// SetDeepRelations marks specific root-qualified relation paths (e.g.
+// "OrgAssessment.OrgOngoingAssessment.OrgQuestionnaires") to be generated as
+// typed nested accessors regardless of the depth cap. Only the listed branches
+// are expanded, so the size cost is limited to exactly those paths.
+func SetDeepRelations(paths []string) { deepRelationPaths = paths }
+
+func relationDepth() int {
+	if relationDepthLimit >= 0 {
+		return relationDepthLimit
+	}
+	if v := os.Getenv("GEN_RELATION_DEPTH"); v != "" {
+		if d, err := strconv.Atoi(v); err == nil && d >= 0 {
+			return d
+		}
+	}
+	return 1 << 30 // effectively unlimited (upstream behavior)
+}
+
+// onDeepPath reports whether path is itself a marked deep relation or an
+// ancestor of one (so the node must be generated to reach the marked leaf).
+func onDeepPath(path string) bool {
+	for _, e := range deepRelationPaths {
+		if e == path || strings.HasPrefix(e, path+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasDeepDescendant reports whether some marked deep path extends past path,
+// i.e. we must recurse into path's children to reach it.
+func hasDeepDescendant(path string) bool {
+	for _, e := range deepRelationPaths {
+		if strings.HasPrefix(e, path+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func pullRelationShip(cache map[string]bool, relationships []*schema.Relationship, depth int, prefix string) []field.Relation {
 	if len(relationships) == 0 {
 		return nil
 	}
-	result := make([]field.Relation, len(relationships))
-	for i, relationship := range relationships {
+	result := make([]field.Relation, 0, len(relationships))
+	for _, relationship := range relationships {
+		nodePath := relationship.Name
+		if prefix != "" {
+			nodePath = prefix + "." + relationship.Name
+		}
+		// Generate this node if it is within the global depth cap, or if it lies
+		// on a marked deep path.
+		if depth < 1 && !onDeepPath(nodePath) {
+			continue
+		}
 		var childRelations []field.Relation
 		varType := strings.TrimLeft(relationship.Field.FieldType.String(), "[]*")
-		if !cache[varType] {
+		recurse := depth > 1 || hasDeepDescendant(nodePath)
+		if recurse && !cache[varType] {
 			cache[varType] = true
 			childRelations = pullRelationShip(cache, append(append(append(append(
 				make([]*schema.Relationship, 0, 4),
@@ -270,9 +337,10 @@ func pullRelationShip(cache map[string]bool, relationships []*schema.Relationshi
 				relationship.FieldSchema.Relationships.HasOne...),
 				relationship.FieldSchema.Relationships.HasMany...),
 				relationship.FieldSchema.Relationships.Many2Many...),
+				depth-1, nodePath,
 			)
 		}
-		result[i] = *field.NewRelationWithType(field.RelationshipType(relationship.Type), relationship.Name, varType, childRelations...)
+		result = append(result, *field.NewRelationWithType(field.RelationshipType(relationship.Type), relationship.Name, varType, childRelations...))
 	}
 	return result
 }

--- a/internal/generate/query.go
+++ b/internal/generate/query.go
@@ -271,8 +271,7 @@ var (
 // (1 = direct relations only). Overrides GEN_RELATION_DEPTH.
 func SetRelationDepth(d int) { relationDepthLimit = d }
 
-// SetDeepRelations marks specific root-qualified relation paths (e.g.
-// "OrgAssessment.OrgOngoingAssessment.OrgQuestionnaires") to be generated as
+// SetDeepRelations marks specific root-qualified relation paths (e.g. "Users.Groups.Permissions") to be generated as
 // typed nested accessors regardless of the depth cap. Only the listed branches
 // are expanded, so the size cost is limited to exactly those paths.
 func SetDeepRelations(paths []string) { deepRelationPaths = paths }


### PR DESCRIPTION
gorm/gen expands the full transitive closure of model relations into nested RelationField structs. In a densely-connected schema this is combinatorial and produces millions of lines of generated code.

RelationDepth(n) caps nested relation generation at n levels (1 = direct relations only). DeepRelations(paths...) marks specific root-qualified relation paths (e.g. "Order.Customer.Address") that stay fully typed past the cap; pullRelationShip threads the root-qualified path and only expands listed branches, so a deep path costs just its own nodes. Defaults preserve upstream behavior (unlimited depth). ParseStructRelationShip now takes the root model name.

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
