### PR TITLE
fix: set ColumnName in FieldNew to generate query fields correctly

### DIFF
--- a/field_options.go
+++ b/field_options.go
@@ -85,13 +85,10 @@ var (
 				Type: fieldType,
 				Tag:  fieldTag,
 			}
-			if gormTags, ok := fieldTag["gorm"]; ok {
-				for _, tag := range strings.Split(gormTags, ";") {
-					tag = strings.TrimSpace(tag)
-					if strings.HasPrefix(tag, "column:") {
-						f.ColumnName = strings.TrimPrefix(tag, "column:")
-						break
-					}
+			if gormTag, ok := fieldTag[field.TagKeyGorm]; ok {
+				settings := schema.ParseTagSetting(gormTag, ";")
+				if col, ok := settings["COLUMN"]; ok {
+					f.ColumnName = col
 				}
 			}
 			return f

--- a/field_options.go
+++ b/field_options.go
@@ -80,11 +80,21 @@ var (
 	// FieldNew add new field (any type your want)
 	FieldNew = func(fieldName, fieldType string, fieldTag field.Tag) model.CreateFieldOpt {
 		return func(*model.Field) *model.Field {
-			return &model.Field{
+			f := &model.Field{
 				Name: fieldName,
 				Type: fieldType,
 				Tag:  fieldTag,
 			}
+			if gormTags, ok := fieldTag["gorm"]; ok {
+				for _, tag := range strings.Split(gormTags, ";") {
+					tag = strings.TrimSpace(tag)
+					if strings.HasPrefix(tag, "column:") {
+						f.ColumnName = strings.TrimPrefix(tag, "column:")
+						break
+					}
+				}
+			}
+			return f
 		}
 	}
 	// FieldIgnore ignore some columns by name

--- a/generator_test.go
+++ b/generator_test.go
@@ -14,6 +14,22 @@ import (
 	"gorm.io/gen/field"
 )
 
+func TestFieldNew(t *testing.T) {
+	// 有 gorm column 标签时设置 ColumnName
+	opt := FieldNew("external_id", "string", field.Tag{field.TagKeyGorm: "column:external_id"})
+	f := opt(nil)
+	if f.ColumnName != "external_id" {
+		t.Errorf("FieldNew with gorm:column tag: expected 'external_id', got '%s'", f.ColumnName)
+	}
+
+	// 没有 gorm column 标签时保留空 ColumnName
+	opt2 := FieldNew("name", "string", field.Tag{})
+	f2 := opt2(nil)
+	if f2.ColumnName != "" {
+		t.Errorf("FieldNew without gorm:column tag: expected empty ColumnName, got '%s'", f2.ColumnName)
+	}
+}
+
 func TestConfig(t *testing.T) {
 	_ = &Config{
 		db: nil,


### PR DESCRIPTION
When using FieldNew to create custom fields, the query template (internal/template/struct.go) checks {{- if .ColumnName -}} before generating the query field. However, FieldNew does not set ColumnName, causing these fields to be silently skipped in the generated query code, even though the model struct is correct.

Fix by extracting the column: value from the gorm tag in FieldNew and setting it as ColumnName on the created Field.