### PR TITLE
feat: add Config.UseAny to emit any instead of interface{}

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Gen has one generator entry point (`gen.NewGenerator(gen.Config{...})`). The mai
 
 - What to generate: DB schema → models/query; plus optional interface-SQL methods
 - How the query API looks: `Config.Mode` flags (`WithDefaultQuery`, `WithoutContext`, `WithQueryInterface`, `WithGeneric`)
+- Code style: `Config.UseAny` emits `any` instead of `interface{}` in generated code (opt-in; target module needs Go 1.18+; also rewrites the literal text `interface{}` in comments and string literals)
 
 ### Setup A: DB schema → model + query (recommended baseline)
 

--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	WithUnitTest bool   // generate unit test for query code
 	Incremental  bool   // skip writing unchanged generated files (based on manifest hash)
 	MergeQuery   bool   // keep previously generated query entries (A+B) when generating subsets
+	UseAny       bool   // emit "any" instead of "interface{}" in generated code (requires Go 1.18+ in the target module)
 
 	// generate model global configuration
 	FieldNullable       bool // generate pointer when field is nullable

--- a/generator.go
+++ b/generator.go
@@ -706,6 +706,16 @@ func (g *Generator) fillModelPkgPath(filePath string) {
 func (g *Generator) format(fileName string, content []byte) ([]byte, error) {
 	result, err := imports.Process(fileName, content, nil)
 	if err == nil {
+		if g.UseAny {
+			// Rewrite the empty interface onto its "any" alias as the last step,
+			// after gofmt normalization: the formatted text spells every empty
+			// interface exactly "interface{}", so a plain ReplaceAll cannot miss
+			// occurrences or touch non-empty interfaces like "interface{ M() }".
+			// Doing it here also lets the incremental manifest hash cover the
+			// final bytes. Literal "interface{}" inside comments and string
+			// literals is rewritten too.
+			result = []byte(strings.ReplaceAll(string(result), "interface{}", "any"))
+		}
 		return result, nil
 	}
 

--- a/generator_useany_test.go
+++ b/generator_useany_test.go
@@ -1,0 +1,53 @@
+package gen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatUseAny(t *testing.T) {
+	src := `package query
+
+// value swaps interface{} spellings (comment mention).
+func value(v interface{}, list []interface{}, m map[string]interface{}) interface{} {
+	var x interface{ M() } = nil
+	_ = x
+	return v
+}
+`
+	g := NewGenerator(Config{OutPath: t.TempDir()})
+
+	t.Run("default keeps interface{} spelling", func(t *testing.T) {
+		out, err := g.format("value.go", []byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(out)
+		if !strings.Contains(got, "v interface{}") || !strings.Contains(got, "map[string]interface{}") {
+			t.Errorf("default output should keep the interface{} spelling:\n%s", got)
+		}
+		if strings.Contains(got, "v any") || strings.Contains(got, "map[string]any") {
+			t.Errorf("default output must not rewrite to any:\n%s", got)
+		}
+	})
+
+	t.Run("UseAny rewrites empty interfaces only", func(t *testing.T) {
+		g.UseAny = true
+		out, err := g.format("value.go", []byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(out)
+		if strings.Contains(got, "interface{}") {
+			t.Errorf("empty interface should be rewritten to any:\n%s", got)
+		}
+		for _, want := range []string{"v any", "[]any", "map[string]any", ") any {"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("rewritten output missing %q:\n%s", want, got)
+			}
+		}
+		if !strings.Contains(got, "interface{ M() }") {
+			t.Errorf("non-empty interface must survive the rewrite:\n%s", got)
+		}
+	})
+}

--- a/internal/generate/clause_test.go
+++ b/internal/generate/clause_test.go
@@ -196,3 +196,17 @@ var m = func() *InterfaceMethod {
 	return m
 
 }
+
+func TestCheckResultRejectsInterfaceReturn(t *testing.T) {
+	for _, typ := range []string{"interface{}", "any"} {
+		m := &InterfaceMethod{
+			InterfaceName: "IF",
+			MethodName:    "M",
+			OriginStruct:  parser.Param{Package: "model", Type: "User"},
+		}
+		err := m.checkResult([]parser.Param{{Type: typ}, {Type: "error"}})
+		if err == nil {
+			t.Errorf("checkResult(%s): expected rejection, got nil", typ)
+		}
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -188,9 +188,9 @@ func (p *Param) IsGenT() bool {
 	return p.Package == "gen" && p.Type == "T"
 }
 
-// IsInterface ...
+// IsInterface ... ("interface{}" or its "any" alias)
 func (p *Param) IsInterface() bool {
-	return p.Type == "interface{}"
+	return p.Package == "" && (p.Type == "interface{}" || p.Type == "any")
 }
 
 // IsNull ...
@@ -283,7 +283,7 @@ func (p *Param) IsBaseType() bool {
 func (p *Param) astGetParamType(param *ast.Field) {
 	switch v := param.Type.(type) {
 	case *ast.Ident:
-		p.Type = v.Name
+		p.Type = normalizeIdentType(v)
 		if v.Obj != nil {
 			p.Package = "UNDEFINED" // set a placeholder
 		}
@@ -315,7 +315,7 @@ func (p *Param) astGetParamType(param *ast.Field) {
 func (p *Param) astGetEltType(expr ast.Expr) {
 	switch v := expr.(type) {
 	case *ast.Ident:
-		p.Type = v.Name
+		p.Type = normalizeIdentType(v)
 		if v.Obj != nil {
 			p.Package = "UNDEFINED"
 		}
@@ -353,9 +353,23 @@ func (p *Param) astGetMapType(expr *ast.MapType) {
 func astGetType(expr ast.Expr) string {
 	switch v := expr.(type) {
 	case *ast.Ident:
-		return v.Name
+		return normalizeIdentType(v)
 	case *ast.InterfaceType:
 		return "interface{}"
 	}
 	return ""
+}
+
+// normalizeIdentType canonicalizes a type identifier: the universe-scope
+// "any" alias is mapped onto the canonical "interface{}" spelling so
+// downstream checks only ever see one form. v.Obj == nil plus no package
+// qualifier identifies the predeclared alias; a user-defined type named
+// "any" in the parsed file resolves to an object and is left alone (a
+// same-named type declared in another file of the package is beyond the
+// file scope go/parser resolves).
+func normalizeIdentType(v *ast.Ident) string {
+	if v.Name == "any" && v.Obj == nil {
+		return "interface{}"
+	}
+	return v.Name
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,132 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const anyInterfaceSrc = `package diy
+
+type TestAny interface {
+	M1(v any) error
+	M2(vs []any) error
+	M3(m map[string]any) error
+	M4(v interface{}) error
+	M5(v *any) error
+	M6(vs ...any) error
+	M7() (any, error)
+}
+`
+
+// a user-defined type named "any" shadows the universe alias and must be
+// treated as an ordinary package type, not canonicalized
+const anyShadowSrc = `package diy
+
+type any struct{ X int }
+
+type TestShadow interface {
+	S(v any) error
+}
+`
+
+func parseInterface(t *testing.T, src, name string) *InterfaceInfo {
+	t.Helper()
+	file := filepath.Join(t.TempDir(), "diy.go")
+	if err := os.WriteFile(file, []byte(src), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	i := &InterfaceSet{}
+	if _, err := i.getInterfaceFromFile(file, name, "gorm.io/x/diy", nil); err != nil {
+		t.Fatal(err)
+	}
+	for idx, info := range i.Interfaces {
+		if info.Name == name {
+			return &i.Interfaces[idx]
+		}
+	}
+	t.Fatalf("interface %s not found in fixture", name)
+	return nil
+}
+
+func TestParseAnyAsCanonicalInterface(t *testing.T) {
+	info := parseInterface(t, anyInterfaceSrc, "TestAny")
+	if len(info.Methods) != 7 {
+		t.Fatalf("unexpected method count: %d", len(info.Methods))
+	}
+
+	shapes := []struct {
+		method       string
+		wantType     string
+		wantArray    bool
+		wantPointer  bool
+		wantVariadic bool
+	}{
+		{method: "M1", wantType: "interface{}"},
+		{method: "M2", wantType: "interface{}", wantArray: true},
+		{method: "M3", wantType: "map[string]interface{}"},
+		{method: "M4", wantType: "interface{}"},
+		{method: "M5", wantType: "interface{}", wantPointer: true},
+		{method: "M6", wantType: "interface{}", wantArray: true, wantVariadic: true},
+		{method: "M7", wantType: "interface{}"},
+	}
+	for _, s := range shapes {
+		var m *Method
+		for _, mm := range info.Methods {
+			if mm.MethodName == s.method {
+				m = mm
+				break
+			}
+		}
+		if m == nil {
+			t.Fatalf("method %s not found", s.method)
+		}
+		if s.method == "M7" {
+			if len(m.Result) != 2 || m.Result[0].Type != s.wantType || !m.Result[1].IsError() {
+				t.Errorf("M7: result = %+v, want (interface{}, error)", m.Result)
+			}
+			continue
+		}
+		if len(m.Params) != 1 {
+			t.Fatalf("%s: unexpected param count: %d", s.method, len(m.Params))
+		}
+		p := m.Params[0]
+		if p.Type != s.wantType {
+			t.Errorf("%s: param type = %q, want %q", s.method, p.Type, s.wantType)
+		}
+		if p.IsArray != s.wantArray {
+			t.Errorf("%s: IsArray = %v, want %v", s.method, p.IsArray, s.wantArray)
+		}
+		if p.IsPointer != s.wantPointer {
+			t.Errorf("%s: IsPointer = %v, want %v", s.method, p.IsPointer, s.wantPointer)
+		}
+		if p.IsVariadic != s.wantVariadic {
+			t.Errorf("%s: IsVariadic = %v, want %v", s.method, p.IsVariadic, s.wantVariadic)
+		}
+	}
+}
+
+func TestParseShadowedAnyStaysUserType(t *testing.T) {
+	info := parseInterface(t, anyShadowSrc, "TestShadow")
+	p := info.Methods[0].Params[0]
+	if p.Type != "any" || p.Package != "UNDEFINED" {
+		t.Errorf("shadowed any: Type = %q, Package = %q, want Type = %q, Package = %q",
+			p.Type, p.Package, "any", "UNDEFINED")
+	}
+}
+
+func TestParamIsInterface(t *testing.T) {
+	for _, c := range []struct {
+		p    Param
+		want bool
+	}{
+		{Param{Type: "interface{}"}, true},
+		{Param{Type: "any"}, true},
+		{Param{Package: "diy", Type: "any"}, false},
+		{Param{Type: "map[string]interface{}"}, false},
+	} {
+		if got := c.p.IsInterface(); got != c.want {
+			t.Errorf("IsInterface(%+v) = %v, want %v", c.p, got, c.want)
+		}
+	}
+}

--- a/tests/generate_test.go
+++ b/tests/generate_test.go
@@ -303,6 +303,36 @@ func Test_GenSkipImpl(t *testing.T) {
 	}
 }
 
+func Test_GenUseAny(t *testing.T) {
+	dir := ".gen/use_any_test"
+	os.RemoveAll(dir)
+	g := gen.NewGenerator(gen.Config{
+		OutPath: dir + "/query",
+		Mode:    gen.WithDefaultQuery | gen.WithQueryInterface,
+
+		UseAny: true,
+	})
+	g.UseDB(DB)
+	model := g.GenerateModel("users")
+	g.ApplyInterface(func(diy_method.TrimTest) {}, model)
+	g.Execute()
+
+	content, err := os.ReadFile(dir + "/query/users.gen.go")
+	if err != nil {
+		t.Fatalf("read generated file failed: %v", err)
+	}
+	str := string(content)
+	if strings.Contains(str, "interface{}") {
+		t.Error("should not contain interface{} when UseAny is enabled")
+	}
+	if !strings.Contains(str, "Scan(result any)") {
+		t.Error("should emit any in CRUD method signatures")
+	}
+	if !strings.Contains(str, "map[string]any") {
+		t.Error("should emit map[string]any for gen.M parameters")
+	}
+}
+
 func Test_GenVariadic(t *testing.T) {
 	dir := ".gen/variadic_test"
 	os.RemoveAll(dir)

--- a/tools/gentool/README.ZH_CN.md
+++ b/tools/gentool/README.ZH_CN.md
@@ -42,6 +42,8 @@ Usage of gentool:
         specify a directory for output (default "./dao/query")
   -tables string
         enter the required data table or leave it blank
+  -useAny
+        emit "any" instead of "interface{}" in generated code (requires Go 1.18+)
   -withDefaultQuery
         create default query in generated code
   -withGeneric
@@ -162,6 +164,12 @@ Value : False / True
 默认: false
 
 为 true 时，生成 query 类的相应接口。
+
+#### useAny
+
+默认: false
+
+为 true 时，在生成代码中使用 `any` 代替 `interface{}`（要求目标模块使用 Go 1.18+ 编译）。注释和字符串字面量中的 `interface{}` 文本也会被一并改写。
 
 #### withoutContext
 

--- a/tools/gentool/README.md
+++ b/tools/gentool/README.md
@@ -42,6 +42,8 @@ Usage of gentool:
         specify a directory for output (default "./dao/query")
   -tables string
         enter the required data table or leave it blank
+  -useAny
+        emit "any" instead of "interface{}" in generated code (requires Go 1.18+)
   -withDefaultQuery
         create default query in generated code
   -withGeneric
@@ -158,6 +160,12 @@ generate code with generic
 Default: false
 
 generate code with exported interface object
+
+#### useAny
+
+Default: false
+
+emit "any" instead of "interface{}" in generated code. Requires the target module to build with Go 1.18 or later. The literal text "interface{}" in comments and string literals is rewritten too.
 
 #### withoutContext
 

--- a/tools/gentool/gen.yml
+++ b/tools/gentool/gen.yml
@@ -41,3 +41,5 @@ database:
   withoutContext: false
   # generate code with exported interface object
   withQueryInterface: false
+  # emit "any" instead of "interface{}" in generated code (requires Go 1.18+)
+  useAny: false

--- a/tools/gentool/gentool.go
+++ b/tools/gentool/gentool.go
@@ -54,6 +54,7 @@ type CmdParams struct {
 	WithoutContext      bool     `yaml:"withoutContext"`      // generate code without context constrain
 	WithQueryInterface  bool     `yaml:"withQueryInterface"`  // generate code with exported interface object
 	WithGeneric         bool     `yaml:"withGeneric"`         // generate code with generic
+	UseAny              bool     `yaml:"useAny"`              // emit "any" instead of "interface{}" in generated code (requires Go 1.18+)
 }
 
 func (c *CmdParams) revise() *CmdParams {
@@ -167,6 +168,7 @@ func argParse() *CmdParams {
 	withoutContext := flag.Bool("withoutContext", false, "generate code without context constrain")
 	withQueryInterface := flag.Bool("withQueryInterface", false, "generate code with exported interface object")
 	withGeneric := flag.Bool("withGeneric", false, "generate code with generic")
+	useAny := flag.Bool("useAny", false, `emit "any" instead of "interface{}" in generated code (requires Go 1.18+)`)
 
 	flag.Parse()
 
@@ -233,6 +235,9 @@ func argParse() *CmdParams {
 	if *withGeneric {
 		cmdParse.WithGeneric = true
 	}
+	if *useAny {
+		cmdParse.UseAny = true
+	}
 
 	return &cmdParse
 }
@@ -275,6 +280,7 @@ func main() {
 		FieldWithTypeTag:    config.FieldWithTypeTag,
 		FieldWithDefaultTag: config.FieldWithDefaultTag,
 		FieldSignable:       config.FieldSignable,
+		UseAny:              config.UseAny,
 		Mode:                generateMode,
 	})
 


### PR DESCRIPTION
## Motivation

Go 1.26's `go fix` modernizes `interface{}` → `any`, but it skips generated files (the `// Code generated ... DO NOT EDIT` header). The generator itself should therefore be able to emit the modern spelling.

Fixes #1483

## What this PR does

**Library (`gorm.io/gen`):**
- New opt-in `Config.UseAny`: when enabled, every generated file emits `any` instead of `interface{}` — query/DO files, the Do interface, DIY method signatures (including the `gen.M` → `map[string]any` expansion), models, `gen.go`, and unit tests.
- Implemented as a post-gofmt rewrite at the single formatting chokepoint `Generator.format`:
  - the rewritten text is gofmt-normalized, so every empty interface is spelled exactly `interface{}` (nothing missed) and non-empty `interface{ M() }` is never touched;
  - the incremental manifest hash covers the final bytes, so toggling `UseAny` correctly rewrites files;
  - default (`false`) output is **byte-identical** to before — all golden fixtures unchanged.
- Generated code using `any` requires the target module to build with Go 1.18+.

**Parser fix:**
- DIY interface signatures may now use `any`: universe-scope `any` is canonicalized to the internal `interface{}` spelling at AST extraction (params, slice/map/pointer/variadic elements, results), while a user-defined type named `any` is correctly left alone (`Obj != nil`).
- `Param.IsInterface()` accepts both spellings — this also fixes a real bug: a DIY method *returning* `any` previously slipped past `checkResult`'s interface rejection and generated broken code referencing e.g. `pkg.any`.

**gentool:** `-useAny` flag + `useAny` yaml field + docs (EN/ZH).

## ⚠️ Note for maintainers: gentool build window

`tools/gentool` is a separate module pinned to the *published* `gorm.io/gen` (v0.3.28), which does not have `Config.UseAny` yet — so `tools/gentool` does not compile at this HEAD until the next gen release + dependency bump (dependabot or manual). Same flow as the `WithGeneric` exposure in #1333 (unbuildable until the bump in #1465). CI does not build the nested module. If preferred, the four gentool files can be split into a same-day follow-up PR right after the tag.

## Behavior notes

- Literal `interface{}` text inside comments and string literals (including custom `UnitTestTemplate` content) is rewritten too — documented in the README and flag help.
- `map[string]interface{}` → `map[string]any` and `[]interface{}` → `[]any` are intended.

## Verification

- TDD: every new test was verified RED before implementation.
- `go test ./...` (root module) ✅
- `go test -count=1 ./...` in `tests/` against real MySQL (docker compose) ✅ — includes byte-exact golden fixture diffs (`tests/.expect/*` zero diff) and the new `Test_GenUseAny` end-to-end test (generates into `.gen/use_any_test`, asserts no `interface{}`, `Scan(result any)`, `map[string]any`).
- `gofmt` clean; `golangci-lint` findings identical to the master baseline (zero new).
- Go 1.18 compatibility: builds/vets under go1.18; the `ast.Ident.Obj` universe-vs-shadow discrimination for `any` was probed empirically on go 1.18/1.20/1.21/1.22/1.23/1.25/1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
