### PR TITLE
ci: enable the gentool build in the modules job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,8 +106,5 @@ jobs:
       - name: Build examples module
         run: cd examples && go build ./...
 
-      # TODO: enable once tools/gentool's gorm.io/gen dependency is bumped to
-      # the first release shipping Config.UseAny (PR #1482); it cannot compile
-      # against the currently published version.
-      # - name: Build gentool module
-      #   run: cd tools/gentool && go build ./...
+      - name: Build gentool module
+        run: cd tools/gentool && go build ./...


### PR DESCRIPTION
Follow-up to #1485: the TODO'd gentool build step is now unblocked — dependabot bumped `tools/gentool` to `gorm.io/gen v0.3.29` (60e0bba), the first release shipping `Config.UseAny` (#1482), so the nested module compiles again.

Verified locally: `go build ./... && go vet ./...` in `tools/gentool` with the bumped dependency pass. The gentool build window opened by #1482 is now closed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)