### PR TITLE
ci: race-test root module, tidy gate, pin golangci-lint

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,4 +12,5 @@ jobs:
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
+          golangci_lint_version: v2.13.1
           golangci_lint_flags: '--timeout 5m'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
     branches-ignore:
       - "gh-pages"
     paths-ignore: ["**.md"]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -41,7 +42,7 @@ jobs:
             examples/go.sum
 
       - name: Tests
-        run: go test ./...
+        run: go test -race ./...
 
   mysql:
     strategy:
@@ -108,3 +109,29 @@ jobs:
 
       - name: Build gentool module
         run: cd tools/gentool && go build ./...
+
+  tidy:
+    name: go mod tidy check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache-dependency-path: |
+            go.sum
+            tests/go.sum
+            tools/gentool/go.sum
+            examples/go.sum
+
+      - name: Check all modules are tidy
+        run: |
+          go mod tidy && git diff --exit-code go.mod go.sum
+          cd tests && go mod tidy && git diff --exit-code go.mod go.sum
+          cd ../tools/gentool && go mod tidy && git diff --exit-code go.mod go.sum
+          cd ../../examples && go mod tidy && git diff --exit-code go.mod go.sum

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -10,9 +10,7 @@ fi
 if [ -d tests ]
 then
   cd tests
-  go get -t ./...
   go mod download
-  go mod tidy
   cd ..
 fi
 


### PR DESCRIPTION
Follow-up to #1485, four small hardening items:

1. **`-race` on the root module** — only the `tests` module had race coverage (via `test.sh`); the root module's generator/pools/manifest code now gets it too. Verified locally: `go test -race ./...` passes on all root packages.
2. **Tidy gate** — `test.sh` no longer runs `go get -t ./... && go mod tidy` (silent mutation that can mask untidy modules); a new `tidy` job runs `go mod tidy && git diff --exit-code` across all four modules. All four verified tidy-stable locally.
3. **Pin `golangci-lint` to `v2.13.1`** in the reviewdog action so lint verdicts are reproducible instead of tracking the latest release.
4. **`workflow_dispatch`** for manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)