### PR TITLE
feat(field): expose NULL as a field literal

### DIFF
--- a/field/export.go
+++ b/field/export.go
@@ -13,6 +13,8 @@ var (
 	Star = NewAsterisk("")
 	// ALL same with Star
 	ALL = Star
+
+	NULL = Field{expr: expr{col: clause.Column{Name: "NULL", Raw: true}}}
 )
 
 // Option field option


### PR DESCRIPTION
Adds an exported `NULL` field to the `field` package, so the NULL literal can be used as an operand in generated query expressions:

```go
field.NULL // clause.Column{Name: "NULL", Raw: true}, no quoting
```

There is currently no way to express a NULL literal: `NewString(table, "NULL")` goes through `toColumn`/`banColumnRaw` and gets quoted as a column name. This revives the 2023 `feature/field` branch (2 lines, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)