### PR TITLE
feat(generate): fail fast on first table generation error

### DIFF
--- a/abort.go
+++ b/abort.go
@@ -1,0 +1,44 @@
+package gen
+
+import "sync"
+
+// abortGroup propagates one generation failure to every participant of a
+// concurrent generation round. Abort records only the first error and closes
+// a broadcast channel, so spawners and workers can observe cancellation
+// through a non-blocking receive without ever blocking on error delivery.
+type abortGroup struct {
+	once sync.Once
+	done chan struct{}
+	errs chan error
+}
+
+func newAbortGroup() *abortGroup {
+	return &abortGroup{done: make(chan struct{}), errs: make(chan error, 1)}
+}
+
+// Aborted returns a channel that is closed once Abort has been called.
+func (a *abortGroup) Aborted() <-chan struct{} {
+	return a.done
+}
+
+// Abort records err as the round's failure and broadcasts cancellation.
+// The send never blocks: errs has capacity one and Abort is the sole sender
+// (guarded by once). The send happens before done is closed, so any caller
+// observing the closed channel can read the recorded error afterwards.
+func (a *abortGroup) Abort(err error) {
+	a.once.Do(func() {
+		a.errs <- err
+		close(a.done)
+	})
+}
+
+// Err drains the single recorded error, if any. Call it after all workers of
+// the round have finished so no failure can race with the drain.
+func (a *abortGroup) Err() error {
+	select {
+	case err := <-a.errs:
+		return err
+	default:
+		return nil
+	}
+}

--- a/abort_test.go
+++ b/abort_test.go
@@ -1,0 +1,56 @@
+package gen
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestAbortGroup(t *testing.T) {
+	errs := newAbortGroup()
+	if err := errs.Err(); err != nil {
+		t.Fatalf("Err() before Abort: expected nil, got %v", err)
+	}
+	select {
+	case <-errs.Aborted():
+		t.Fatal("Aborted() should not be closed before Abort")
+	default:
+	}
+
+	sentinel := errors.New("first failure")
+	errs.Abort(sentinel)
+	errs.Abort(errors.New("ignored")) // only the first error wins
+
+	if got := errs.Err(); !errors.Is(got, sentinel) {
+		t.Fatalf("Err(): expected first error, got %v", got)
+	}
+	select {
+	case <-errs.Aborted():
+	default:
+		t.Fatal("Aborted() should be closed after Abort")
+	}
+}
+
+func TestAbortGroupConcurrentAbort(t *testing.T) {
+	errs := newAbortGroup()
+	const n = 64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			errs.Abort(fmt.Errorf("failure %d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	if got := errs.Err(); got == nil {
+		t.Fatal("expected exactly one recorded error after concurrent Aborts")
+	}
+	select {
+	case <-errs.Aborted():
+	default:
+		t.Fatal("Aborted() should be closed after concurrent Aborts")
+	}
+}

--- a/generator.go
+++ b/generator.go
@@ -324,41 +324,42 @@ func (g *Generator) generateQueryFile() (err error) {
 		manifest.Mode = uint(g.Mode)
 	}
 
-	var errOnce sync.Once
-	errChan := make(chan error, 1)
+	errs := newAbortGroup()
 	pool := pools.NewPool(concurrent)
-	// generate query code for all struct
+	// generate query code for all struct, stopping as soon as any table fails
+queryLoop:
 	for _, info := range g.Data {
+		select {
+		case <-errs.Aborted(): // stop scheduling further tables
+			break queryLoop
+		default:
+		}
 		pool.Wait()
 		go func(info *genInfo) {
 			defer pool.Done()
-			err := g.generateSingleQueryFile(info, manifest, &manifestMu)
-			if err != nil {
-				errOnce.Do(func() {
-					errChan <- err
-				})
+			select {
+			case <-errs.Aborted(): // a sibling already failed; skip wasted work
+				return
+			default:
+			}
+
+			if err := g.generateSingleQueryFile(info, manifest, &manifestMu); err != nil {
+				errs.Abort(err)
 				return
 			}
 
 			if g.WithUnitTest {
-				err = g.generateQueryUnitTestFile(info, manifest, &manifestMu)
-				if err != nil { // do not panic
+				if err := g.generateQueryUnitTestFile(info, manifest, &manifestMu); err != nil { // do not panic
 					g.db.Logger.Error(context.Background(), "generate unit test fail: %s", err)
 					return
 				}
 			}
 		}(info)
 	}
-	select {
-	case err = <-errChan:
+	// wait for in-flight workers to wind down before draining the failure
+	<-pool.AsyncWaitAll()
+	if err := errs.Err(); err != nil {
 		return err
-	case <-pool.AsyncWaitAll():
-		// check queued error when both select cases are ready and pool wins
-		select {
-		case err = <-errChan:
-			return err
-		default:
-		}
 	}
 
 	genForRoot := *g
@@ -633,56 +634,67 @@ func (g *Generator) generateModelFile() error {
 		manifest.Mode = uint(g.Mode)
 	}
 
-	errChan := make(chan error)
+	errs := newAbortGroup()
 	pool := pools.NewPool(concurrent)
+modelLoop:
 	for _, data := range g.models {
 		if data == nil || !data.Generated {
 			continue
 		}
+		select {
+		case <-errs.Aborted(): // stop scheduling further tables
+			break modelLoop
+		default:
+		}
 		pool.Wait()
 		go func(data *generate.QueryStructMeta) {
 			defer pool.Done()
+			select {
+			case <-errs.Aborted(): // a sibling already failed; skip wasted work
+				return
+			default:
+			}
 
 			var buf bytes.Buffer
-			err := render(tmpl.Model, &buf, data)
-			if err != nil {
-				errChan <- err
+			if err := render(tmpl.Model, &buf, data); err != nil {
+				errs.Abort(err)
 				return
 			}
 
 			for _, method := range data.ModelMethods {
-				err = render(tmpl.ModelMethod, &buf, method)
-				if err != nil {
-					errChan <- err
+				if err := render(tmpl.ModelMethod, &buf, method); err != nil {
+					errs.Abort(err)
 					return
 				}
 			}
 
 			modelFile := modelOutPath + data.FileName + ".gen.go"
+			var err error
 			if manifestEnabled {
 				err = g.outputWithManifest(modelFile, buf.Bytes(), manifest, filepath.Base(modelFile), &manifestMu)
 			} else {
 				err = g.output(modelFile, buf.Bytes())
 			}
 			if err != nil {
-				errChan <- err
+				errs.Abort(err)
 				return
 			}
 
 			g.info(fmt.Sprintf("generate model file(table <%s> -> {%s.%s}): %s", data.TableName, data.StructInfo.Package, data.StructInfo.Type, modelFile))
 		}(data)
 	}
-	select {
-	case err = <-errChan:
+	// wait for in-flight workers to wind down before draining the failure
+	<-pool.AsyncWaitAll()
+	if err := errs.Err(); err != nil {
+		// the round failed; skip manifest persistence and pkg path detection
 		return err
-	case <-pool.AsyncWaitAll():
-		if manifestEnabled {
-			if err := saveManifest(manifestPath, manifest); err != nil {
-				return err
-			}
-		}
-		g.fillModelPkgPath(modelOutPath)
 	}
+	if manifestEnabled {
+		if err := saveManifest(manifestPath, manifest); err != nil {
+			return err
+		}
+	}
+	g.fillModelPkgPath(modelOutPath)
 	return nil
 }
 


### PR DESCRIPTION
### What did this pull request do?

Follow-up to #1331 (the buffered-channel fix). That PR removed the blocking-send/deadlock surface, but a failure still let the spawn loops sweep **every** remaining table before reporting. This PR restores the intended abort-on-first-error semantics with explicit cancellation.

Introduces an unexported `abortGroup`:

- `Abort(err)` records only the first error (via `sync.Once`) and closes a broadcast channel — the send can never block (capacity 1, sole sender).
- The spawn loop checks the broadcast **before scheduling each table** and stops when cancelled.
- Already-running workers re-check before starting work, so siblings fail out instead of doing wasted renders.
- After all in-flight workers wind down (`<-` `pool.AsyncWaitAll()`), the single recorded error is drained deterministically — which also removes #1331's post-select drain race handling entirely.

Applied consistently to both concurrent rounds in `generator.go`:

- `generateQueryFile`
- `generateModelFile` — previously still a raw unbuffered channel with multiple blocking send sites

On success, behavior is unchanged; on failure, remaining tables are no longer attempted, in-flight tables finish their current unit, and the first error is returned as before.

### Checks

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested