### PR TITLE
fix(gen): wrap custom template render errors with model context

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -661,9 +661,9 @@ modelLoop:
 				return
 			}
 
-			for _, customTemplate := range data.CustomTemplates {
+			for i, customTemplate := range data.CustomTemplates {
 				if err := render(customTemplate, &buf, data); err != nil {
-					errs.Abort(err)
+					errs.Abort(fmt.Errorf("render custom template #%d for model %s: %w", i+1, data.ModelStructName, err))
 					return
 				}
 			}
@@ -820,7 +820,7 @@ func render(tmpl string, wr io.Writer, data interface{}) error {
 	if tmpl == "" {
 		return nil
 	}
-	t, err := template.New(tmpl).Parse(tmpl)
+	t, err := template.New("gen").Parse(tmpl)
 	if err != nil {
 		return err
 	}

--- a/generator_template_test.go
+++ b/generator_template_test.go
@@ -1,0 +1,41 @@
+package gen
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gorm.io/gen/internal/generate"
+	"gorm.io/gen/internal/parser"
+)
+
+func TestGenerateModelFileWrapsCustomTemplateError(t *testing.T) {
+	g := NewGenerator(Config{
+		OutPath: filepath.Join(t.TempDir(), "query"),
+		Mode:    WithDefaultQuery,
+	})
+	g.models = map[string]*generate.QueryStructMeta{
+		"User": {
+			Generated:       true,
+			FileName:        "users",
+			TableName:       "users",
+			ModelStructName: "User",
+			QueryStructName: "user",
+			S:               "u",
+			StructInfo:      parser.Param{Type: "User"},
+			CustomTemplates: []string{"// ok {{.ModelStructName}}", "{{invalid"},
+		},
+	}
+
+	err := g.generateModelFile()
+	if err == nil {
+		t.Fatal("generateModelFile() = nil, want error for invalid custom template")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "custom template #2") {
+		t.Errorf("error message missing custom template index: %s", msg)
+	}
+	if !strings.Contains(msg, "User") {
+		t.Errorf("error message missing model name: %s", msg)
+	}
+}


### PR DESCRIPTION
Fixes #1502.

### What did this pull request do?

When a custom model template (`gen.WithTemplate`, from #1423) fails to parse or execute, `generateModelFile` previously forwarded the raw `text/template` error. With multiple models × multiple templates there was no way to tell which model or which template failed.

- Wrap the failure: `render custom template #<i> for model <ModelStructName>: <err>`
- Give `render()` a stable template name ("gen") instead of using the template body as the name, so parse errors stop echoing the whole template body on every position line
- Regression test drives `generateModelFile` directly with an injected meta (no DB needed) and asserts the index and model name appear in the error

### Checks

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested