### PR TITLE
feat(gen): apply model opts in GenerateModelFrom path

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -661,9 +661,9 @@ modelLoop:
 				return
 			}
 
-			for _, customTemplate := range data.CustomTemplates {
+			for i, customTemplate := range data.CustomTemplates {
 				if err := render(customTemplate, &buf, data); err != nil {
-					errs.Abort(err)
+					errs.Abort(fmt.Errorf("render custom template #%d for model %s: %w", i+1, data.ModelStructName, err))
 					return
 				}
 			}
@@ -820,7 +820,7 @@ func render(tmpl string, wr io.Writer, data interface{}) error {
 	if tmpl == "" {
 		return nil
 	}
-	t, err := template.New(tmpl).Parse(tmpl)
+	t, err := template.New("gen").Parse(tmpl)
 	if err != nil {
 		return err
 	}

--- a/generator.go
+++ b/generator.go
@@ -214,6 +214,7 @@ func (g *Generator) genModelObjConfig() *model.Config {
 	return &model.Config{
 		ModelPkg:       g.Config.ModelPkgPath,
 		ImportPkgPaths: g.importPkgPaths,
+		ModelOpts:      g.modelOpts,
 		NameStrategy: model.NameStrategy{
 			TableNameNS: g.tableNameNS,
 			ModelNameNS: g.modelNameNS,

--- a/generator_template_test.go
+++ b/generator_template_test.go
@@ -1,10 +1,13 @@
 package gen
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"gorm.io/gen/field"
+	"gorm.io/gen/helper"
 	"gorm.io/gen/internal/generate"
 	"gorm.io/gen/internal/parser"
 )
@@ -37,5 +40,62 @@ func TestGenerateModelFileWrapsCustomTemplateError(t *testing.T) {
 	}
 	if !strings.Contains(msg, "User") {
 		t.Errorf("error message missing model name: %s", msg)
+	}
+}
+
+type templateObjectField struct {
+	name string
+	typ  string
+}
+
+func (f templateObjectField) Name() string       { return f.name }
+func (f templateObjectField) Type() string       { return f.typ }
+func (f templateObjectField) ColumnName() string { return strings.ToLower(f.name) }
+func (templateObjectField) GORMTag() string      { return "" }
+func (templateObjectField) JSONTag() string      { return "" }
+func (templateObjectField) Tag() field.Tag       { return nil }
+func (templateObjectField) Comment() string      { return "" }
+
+type templateObject struct {
+	structName string
+}
+
+func (templateObject) TableName() string        { return "template_users" }
+func (o templateObject) StructName() string     { return o.structName }
+func (templateObject) FileName() string         { return "" }
+func (templateObject) ImportPkgPaths() []string { return nil }
+func (o templateObject) Fields() []helper.Field {
+	return []helper.Field{templateObjectField{name: "Name", typ: "string"}}
+}
+
+func TestGenerateModelFromAppliesWithTemplate(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "query")
+	g := NewGenerator(Config{
+		OutPath: outPath,
+		Mode:    WithDefaultQuery,
+	})
+	g.WithOpts(WithTemplate("// custom marker for {{.ModelStructName}}"))
+
+	meta := g.GenerateModelFrom(templateObject{structName: "TemplateUser"})
+	if meta == nil {
+		t.Fatal("GenerateModelFrom() = nil")
+	}
+	if len(meta.CustomTemplates) != 1 {
+		t.Fatalf("CustomTemplates = %v, want the WithTemplate entry", meta.CustomTemplates)
+	}
+
+	if panicValue := executePanic(g); panicValue != nil {
+		t.Fatalf("Execute() panicked: %v", panicValue)
+	}
+	modelDir, err := g.getModelOutputPath()
+	if err != nil {
+		t.Fatalf("resolve model output path: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(modelDir, meta.FileName+".gen.go"))
+	if err != nil {
+		t.Fatalf("read generated model: %v", err)
+	}
+	if !strings.Contains(string(content), "// custom marker for TemplateUser") {
+		t.Errorf("custom template output missing from generated model file:\n%s", content)
 	}
 }

--- a/generator_template_test.go
+++ b/generator_template_test.go
@@ -1,0 +1,41 @@
+package gen
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gorm.io/gen/internal/generate"
+	"gorm.io/gen/internal/parser"
+)
+
+func TestGenerateModelFileWrapsCustomTemplateError(t *testing.T) {
+	g := NewGenerator(Config{
+		OutPath: filepath.Join(t.TempDir(), "query"),
+		Mode:    WithDefaultQuery,
+	})
+	g.models = map[string]*generate.QueryStructMeta{
+		"User": {
+			Generated:       true,
+			FileName:        "users",
+			TableName:       "users",
+			ModelStructName: "User",
+			QueryStructName: "user",
+			S:               "u",
+			StructInfo:      parser.Param{Type: "User"},
+			CustomTemplates: []string{"// ok {{.ModelStructName}}", "{{invalid"},
+		},
+	}
+
+	err := g.generateModelFile()
+	if err == nil {
+		t.Fatal("generateModelFile() = nil, want error for invalid custom template")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "custom template #2") {
+		t.Errorf("error message missing custom template index: %s", msg)
+	}
+	if !strings.Contains(msg, "User") {
+		t.Errorf("error message missing model name: %s", msg)
+	}
+}

--- a/internal/generate/export.go
+++ b/internal/generate/export.go
@@ -117,7 +117,7 @@ func GetQueryStructMetaFromObject(obj helper.Object, conf *model.Config) (*Query
 		fields = append(fields, &nf)
 	}
 
-	return &QueryStructMeta{
+	meta := &QueryStructMeta{
 		Source:          model.Object,
 		Generated:       true,
 		FileName:        fileName,
@@ -128,7 +128,8 @@ func GetQueryStructMetaFromObject(obj helper.Object, conf *model.Config) (*Query
 		StructInfo:      parser.Param{Type: structName, Package: conf.ModelPkg},
 		ImportPkgPaths:  append(conf.ImportPkgPaths, obj.ImportPkgPaths()...),
 		Fields:          fields,
-	}, nil
+	}
+	return meta.addMethodFromAddMethodOpt(conf.GetModelMethods()...).addCustomTemplateFromOpt(conf.GetCustomTemplates()...), nil
 }
 
 // ConvertStructs convert to base structures


### PR DESCRIPTION
Fixes #1501.

**Stacked on #1503** (shares the `generator_template_test.go` file); merge that first and this PR reduces to its own commit.

### What did this pull request do?

`GetQueryStructMetaFromObject` (the `GenerateModelFrom` path) never received the generator's model opts, so `gen.WithTemplate` / `gen.WithMethod` set via `g.WithOpts(...)` were silently ignored for object-built models.

- Wire `g.modelOpts` into `genModelObjConfig`
- Chain the same `addMethodFromAddMethodOpt` / `addCustomTemplateFromOpt` calls the DB-reflection path (`GetQueryStructMeta`) already uses

Both options now behave uniformly across the two paths. Test drives `GenerateModelFrom` + `WithOpts(WithTemplate)` end to end (meta carries the template; rendered output lands in the generated model file) and fails on master.

### Checks

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested